### PR TITLE
feat: athena/cur opencost integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ EXAMPLES := \
     examples/observestacks/minimal.yaml:: \
     examples/observestacks/pvc.yaml:: \
     examples/observestacks/s3.yaml:: \
+    examples/observestacks/cloud-costs.yaml:: \
     examples/observestacks/nodepool.yaml:: \
     examples/observestacks/spot-feed.yaml:: \
     examples/observestacks/metrics-server.yaml::

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ When enabled:
 - ObserveStack derives CUR/Athena names from the referenced `CostReport`
 - OpenCost is wired through the chart's native `cloudIntegrationSecret` support
 - The OpenCost PodIdentity gets Athena, Glue, and S3 permissions for the CUR bucket/workgroup
-- The generated `cloud-integration.json` uses the Athena query-results location `s3://{bucketName}/athena-results`
+- The generated `cloud-integration.json` uses OpenCost's legacy flat AWS format with the Athena query-results location `s3://{bucketName}/athena-results`
 
 `CostReport` is account-level and should be managed separately, one per AWS account. If your `CostReport` uses non-default names, set the corresponding overrides under `cloudCosts.costReportRef`. The legacy manual `cloudCosts` fields still work as a fallback.
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,40 @@ When enabled:
 
 > **Prerequisite:** Deploy a `SpotFeed` XRD in the same AWS account first. See [aws-spot-feed](https://github.com/hops-ops/aws-spot-feed).
 
+### Cloud Costs via CUR/Athena
+
+Enable full AWS cloud cost ingestion in OpenCost by referencing a separately managed `CostReport` XR:
+
+```yaml
+apiVersion: aws.hops.ops.com.ai/v1alpha1
+kind: CostReport
+metadata:
+  name: hops-root-account
+  namespace: default
+spec:
+  accountId: "123456789012"
+  region: us-east-2
+---
+spec:
+  clusterName: my-cluster
+  aws:
+    region: us-east-2
+  cloudCosts:
+    costReportRef:
+      enabled: true
+      name: hops-root-account
+      accountId: "123456789012"
+      region: us-east-2
+```
+
+When enabled:
+- ObserveStack derives CUR/Athena names from the referenced `CostReport`
+- OpenCost is wired through the chart's native `cloudIntegrationSecret` support
+- The OpenCost PodIdentity gets Athena, Glue, and S3 permissions for the CUR bucket/workgroup
+- The generated `cloud-integration.json` uses the Athena query-results location `s3://{bucketName}/athena-results`
+
+`CostReport` is account-level and should be managed separately, one per AWS account. If your `CostReport` uses non-default names, set the corresponding overrides under `cloudCosts.costReportRef`. The legacy manual `cloudCosts` fields still work as a fallback.
+
 ## What Gets Created
 
 1. **Helm Releases** - Prometheus, Loki, Tempo, k8s-monitoring/OpenCost, Grafana Operator, VPA, Goldilocks

--- a/README.md
+++ b/README.md
@@ -148,11 +148,18 @@ spec:
   accountId: "123456789012"
   region: us-east-2
 ---
+apiVersion: aws.hops.ops.com.ai/v1alpha1
+kind: ObserveStack
+metadata:
+  name: observe
+  namespace: default
 spec:
-  clusterName: my-cluster
+  clusterName: production
+  namespace: monitoring
   aws:
     region: us-east-2
   cloudCosts:
+    enabled: true
     costReportRef:
       enabled: true
       name: hops-root-account

--- a/apis/observestacks/definition.yaml
+++ b/apis/observestacks/definition.yaml
@@ -548,6 +548,64 @@ spec:
                   prefix:
                     description: S3 key prefix for spot datafeed files.
                     type: string
+              cloudCosts:
+                description: AWS cloud cost integration via CUR/Athena for OpenCost. Requires a CostReport XRD deployed in the same AWS account.
+                type: object
+                properties:
+                  enabled:
+                    description: Whether to enable cloud cost integration via Athena. Defaults to false.
+                    type: boolean
+                    default: false
+                  costReportRef:
+                    description: Reference information for a separately managed CostReport XR. Use this to derive CUR/Athena names from the account-level CostReport.
+                    type: object
+                    properties:
+                      enabled:
+                        description: Whether to derive cloudCosts settings from a separately managed CostReport. When true, this also enables cloudCosts.
+                        type: boolean
+                        default: false
+                      name:
+                        description: Name of the CostReport XR. Required when enabled.
+                        type: string
+                      namespace:
+                        description: Namespace of the CostReport XR. Defaults to the ObserveStack namespace.
+                        type: string
+                      accountId:
+                        description: AWS account ID for the CostReport XR. Required when enabled.
+                        type: string
+                      region:
+                        description: AWS region for the CostReport XR. Defaults to aws.region.
+                        type: string
+                      bucketName:
+                        description: S3 bucket name override from the CostReport. Defaults to {name}-cur.
+                        type: string
+                      reportName:
+                        description: CUR report/table name override from the CostReport. Defaults to {name}_cur.
+                        type: string
+                      databaseName:
+                        description: Glue catalog database name override from the CostReport. Defaults to {name}_cur.
+                        type: string
+                      workgroupName:
+                        description: Athena workgroup name override from the CostReport. Defaults to {name}-cur-workgroup.
+                        type: string
+                  bucketName:
+                    description: "Manual fallback: base S3 bucket name used for CUR storage and Athena results. OpenCost derives the Athena query-results location as s3://{bucketName}/athena-results."
+                    type: string
+                  region:
+                    description: "Manual fallback: AWS region of the Athena workgroup and Glue database. Defaults to aws.region."
+                    type: string
+                  accountId:
+                    description: "Manual fallback: AWS account ID. Required when enabled without cloudCosts.costReportRef."
+                    type: string
+                  databaseName:
+                    description: "Manual fallback: Glue catalog database name containing CUR tables. Required when enabled without cloudCosts.costReportRef."
+                    type: string
+                  tableName:
+                    description: "Manual fallback: Glue table name for CUR data. Typically the CUR report name (with underscores)."
+                    type: string
+                  workgroupName:
+                    description: "Manual fallback: Athena workgroup name. Required when enabled without cloudCosts.costReportRef."
+                    type: string
             required:
             - clusterName
             - aws

--- a/apis/observestacks/definition.yaml
+++ b/apis/observestacks/definition.yaml
@@ -551,6 +551,23 @@ spec:
               cloudCosts:
                 description: AWS cloud cost integration via CUR/Athena for OpenCost. Requires a CostReport XRD deployed in the same AWS account.
                 type: object
+                x-kubernetes-validations:
+                - rule: "self.enabled != true || (has(self.costReportRef) && self.costReportRef.enabled == true) || (has(self.bucketName) && self.bucketName != '')"
+                  message: cloudCosts.bucketName is required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true.
+                - rule: "self.enabled != true || (has(self.costReportRef) && self.costReportRef.enabled == true) || (has(self.accountId) && self.accountId != '')"
+                  message: cloudCosts.accountId is required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true.
+                - rule: "self.enabled != true || (has(self.costReportRef) && self.costReportRef.enabled == true) || (has(self.databaseName) && self.databaseName != '')"
+                  message: cloudCosts.databaseName is required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true.
+                - rule: "self.enabled != true || (has(self.costReportRef) && self.costReportRef.enabled == true) || (has(self.tableName) && self.tableName != '')"
+                  message: cloudCosts.tableName is required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true.
+                - rule: "self.enabled != true || (has(self.costReportRef) && self.costReportRef.enabled == true) || (has(self.workgroupName) && self.workgroupName != '')"
+                  message: cloudCosts.workgroupName is required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true.
+                - rule: "!has(self.costReportRef) || self.costReportRef.enabled != true || self.enabled == true"
+                  message: cloudCosts.enabled must be true when cloudCosts.costReportRef.enabled is true.
+                - rule: "!has(self.costReportRef) || self.costReportRef.enabled != true || (has(self.costReportRef.name) && self.costReportRef.name != '')"
+                  message: cloudCosts.costReportRef.name is required when cloudCosts.costReportRef.enabled is true.
+                - rule: "!has(self.costReportRef) || self.costReportRef.enabled != true || (has(self.costReportRef.accountId) && self.costReportRef.accountId != '')"
+                  message: cloudCosts.costReportRef.accountId is required when cloudCosts.costReportRef.enabled is true.
                 properties:
                   enabled:
                     description: Whether to enable cloud cost integration via Athena. Defaults to false.
@@ -561,7 +578,7 @@ spec:
                     type: object
                     properties:
                       enabled:
-                        description: Whether to derive cloudCosts settings from a separately managed CostReport. When true, this also enables cloudCosts.
+                        description: Whether to derive cloudCosts settings from a separately managed CostReport. When true, cloudCosts.enabled must also be true.
                         type: boolean
                         default: false
                       name:
@@ -589,22 +606,22 @@ spec:
                         description: Athena workgroup name override from the CostReport. Defaults to {name}-cur-workgroup.
                         type: string
                   bucketName:
-                    description: "Manual fallback: base S3 bucket name used for CUR storage and Athena results. OpenCost derives the Athena query-results location as s3://{bucketName}/athena-results."
+                    description: "Manual fallback: base S3 bucket name used for CUR storage and Athena results. OpenCost derives the Athena query-results location as s3://{bucketName}/athena-results. Required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true."
                     type: string
                   region:
                     description: "Manual fallback: AWS region of the Athena workgroup and Glue database. Defaults to aws.region."
                     type: string
                   accountId:
-                    description: "Manual fallback: AWS account ID. Required when enabled without cloudCosts.costReportRef."
+                    description: "Manual fallback: AWS account ID. Required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true."
                     type: string
                   databaseName:
-                    description: "Manual fallback: Glue catalog database name containing CUR tables. Required when enabled without cloudCosts.costReportRef."
+                    description: "Manual fallback: Glue catalog database name containing CUR tables. Required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true."
                     type: string
                   tableName:
-                    description: "Manual fallback: Glue table name for CUR data. Typically the CUR report name (with underscores)."
+                    description: "Manual fallback: Glue table name for CUR data. Typically the CUR report name (with underscores). Required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true."
                     type: string
                   workgroupName:
-                    description: "Manual fallback: Athena workgroup name. Required when enabled without cloudCosts.costReportRef."
+                    description: "Manual fallback: Athena workgroup name. Required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true."
                     type: string
             required:
             - clusterName

--- a/examples/observestacks/cloud-costs.yaml
+++ b/examples/observestacks/cloud-costs.yaml
@@ -9,6 +9,7 @@ spec:
   aws:
     region: us-east-2
   cloudCosts:
+    enabled: true
     costReportRef:
       enabled: true
       name: hops-root-account

--- a/examples/observestacks/cloud-costs.yaml
+++ b/examples/observestacks/cloud-costs.yaml
@@ -1,0 +1,16 @@
+apiVersion: aws.hops.ops.com.ai/v1alpha1
+kind: ObserveStack
+metadata:
+  name: observe
+  namespace: default
+spec:
+  clusterName: production
+  namespace: monitoring
+  aws:
+    region: us-east-2
+  cloudCosts:
+    costReportRef:
+      enabled: true
+      name: hops-root-account
+      accountId: "123456789012"
+      region: us-east-2

--- a/functions/render/000-state-init.yaml.gotmpl
+++ b/functions/render/000-state-init.yaml.gotmpl
@@ -223,6 +223,32 @@
 {{- $spotFeedEnabled := $spotFeed.enabled | default false }}
 
 # ==============================================================================
+# Cloud cost configuration (CUR/Athena)
+# ==============================================================================
+{{- $cloudCosts := $spec.cloudCosts | default dict }}
+{{- $cloudCostsConfigEnabled := $cloudCosts.enabled | default false }}
+{{- $cloudCostsCostReportRef := $cloudCosts.costReportRef | default dict }}
+{{- $cloudCostsCostReportRefEnabled := $cloudCostsCostReportRef.enabled | default false }}
+{{- $cloudCostsEnabled := or $cloudCostsConfigEnabled $cloudCostsCostReportRefEnabled }}
+{{- $cloudCostsSecretName := printf "%s-cloud-integration" $name }}
+{{- $cloudCostsBucketName := $cloudCosts.bucketName | default "" }}
+{{- $cloudCostsRegion := $cloudCosts.region | default $awsRegion }}
+{{- $cloudCostsAccountId := $cloudCosts.accountId | default "" }}
+{{- $cloudCostsDatabaseName := $cloudCosts.databaseName | default "" }}
+{{- $cloudCostsTableName := $cloudCosts.tableName | default "" }}
+{{- $cloudCostsWorkgroupName := $cloudCosts.workgroupName | default "" }}
+{{- $cloudCostsCostReportRefName := $cloudCostsCostReportRef.name | default "" }}
+{{- $cloudCostsCostReportRefNameUnderscored := $cloudCostsCostReportRefName | replace "-" "_" }}
+{{- if $cloudCostsCostReportRefEnabled }}
+  {{- $cloudCostsBucketName = $cloudCostsCostReportRef.bucketName | default (printf "%s-cur" $cloudCostsCostReportRefName) }}
+  {{- $cloudCostsRegion = $cloudCostsCostReportRef.region | default $awsRegion }}
+  {{- $cloudCostsAccountId = $cloudCostsCostReportRef.accountId | default "" }}
+  {{- $cloudCostsDatabaseName = $cloudCostsCostReportRef.databaseName | default (printf "%s_cur" $cloudCostsCostReportRefNameUnderscored) }}
+  {{- $cloudCostsTableName = $cloudCostsCostReportRef.reportName | default (printf "%s_cur" $cloudCostsCostReportRefNameUnderscored) }}
+  {{- $cloudCostsWorkgroupName = $cloudCostsCostReportRef.workgroupName | default (printf "%s-cur-workgroup" $cloudCostsCostReportRefName) }}
+{{- end }}
+
+# ==============================================================================
 # Initialize $state
 # ==============================================================================
 {{- $state := dict
@@ -357,6 +383,27 @@
     "region" ($spotFeed.region | default $awsRegion)
     "accountId" ($spotFeed.accountId | default "")
     "prefix" ($spotFeed.prefix | default "")
+  )
+  "cloudCosts" (dict
+    "enabled" $cloudCostsEnabled
+    "secretName" $cloudCostsSecretName
+    "bucketName" $cloudCostsBucketName
+    "region" $cloudCostsRegion
+    "accountId" $cloudCostsAccountId
+    "databaseName" $cloudCostsDatabaseName
+    "tableName" $cloudCostsTableName
+    "workgroupName" $cloudCostsWorkgroupName
+    "costReportRef" (dict
+      "enabled" $cloudCostsCostReportRefEnabled
+      "name" $cloudCostsCostReportRefName
+      "namespace" ($cloudCostsCostReportRef.namespace | default ($metadata.namespace | default "default"))
+      "accountId" ($cloudCostsCostReportRef.accountId | default "")
+      "region" ($cloudCostsCostReportRef.region | default $awsRegion)
+      "bucketName" ($cloudCostsCostReportRef.bucketName | default "")
+      "reportName" ($cloudCostsCostReportRef.reportName | default "")
+      "databaseName" ($cloudCostsCostReportRef.databaseName | default "")
+      "workgroupName" ($cloudCostsCostReportRef.workgroupName | default "")
+    )
   )
   "observed" (dict)
   "status" (dict)

--- a/functions/render/000-state-init.yaml.gotmpl
+++ b/functions/render/000-state-init.yaml.gotmpl
@@ -230,7 +230,7 @@
 {{- $cloudCostsCostReportRef := $cloudCosts.costReportRef | default dict }}
 {{- $cloudCostsCostReportRefEnabled := $cloudCostsCostReportRef.enabled | default false }}
 {{- $cloudCostsEnabled := or $cloudCostsConfigEnabled $cloudCostsCostReportRefEnabled }}
-{{- $cloudCostsSecretName := printf "%s-cloud-integration" $name }}
+{{- $cloudCostsSecretName := "opencost-cloud-integration" }}
 {{- $cloudCostsBucketName := $cloudCosts.bucketName | default "" }}
 {{- $cloudCostsRegion := $cloudCosts.region | default $awsRegion }}
 {{- $cloudCostsAccountId := $cloudCosts.accountId | default "" }}

--- a/functions/render/010-state-status.yaml.gotmpl
+++ b/functions/render/010-state-status.yaml.gotmpl
@@ -26,7 +26,7 @@
 # ==============================================================================
 # Set observed state
 # ==============================================================================
-{{- $state = set $state "observed" (dict
+{{- $state = set $state "observed" (merge $state.observed (dict
   "kubePrometheusStack" (dict "ready" (get $checkReady "kube-prometheus-stack"))
   "loki" (dict "ready" (get $checkReady "loki"))
   "tempo" (dict "ready" (get $checkReady "tempo"))
@@ -42,7 +42,7 @@
   "vpa" (dict "ready" (get $checkReady "vpa"))
   "goldilocks" (dict "ready" (get $checkReady "goldilocks"))
   "nodepoolObserve" (dict "ready" (get $checkReady "nodepool-observe"))
-) }}
+)) }}
 
 # ==============================================================================
 # Compute status (readiness determined by function-auto-ready)

--- a/functions/render/230-k8s-monitoring.yaml.gotmpl
+++ b/functions/render/230-k8s-monitoring.yaml.gotmpl
@@ -35,8 +35,14 @@ spec:
       "enabled" true
       "metricsSource" "prometheus"
       "opencost" (dict
-        "exporter" (dict "defaultClusterId" $state.clusterName)
+        "exporter" (dict
+          "defaultClusterId" $state.clusterName
+          "extraEnv" (dict
+            "CLOUD_COST_CONFIG_PATH" "/var/configs/cloud-integration/cloud-integration.json"
+          )
+        )
         "prometheus" (dict "external" (dict "url" (printf "http://%s.%s:9090" $kps.prometheusServiceName $kps.namespace)))
+        "ui" (dict "enabled" true)
       )
     }}
     {{- /* DaemonSets (alloy-logs, alloy-receiver) tolerate ALL taints so they run on
@@ -51,25 +57,35 @@ spec:
     {{- $alloyOperator := dict }}
     {{- $nodeExporterValues := dict "enabled" true }}
     {{- if $state.nodePool.enabled }}
-      {{- $_ := set $opencostValues "opencost" (dict
-        "exporter" (dict "defaultClusterId" $state.clusterName)
-        "prometheus" (dict "external" (dict "url" (printf "http://%s.%s:9090" $kps.prometheusServiceName $kps.namespace)))
-        "nodeSelector" $state.nodePool.nodeSelector
-        "tolerations" $state.nodePool.tolerations
-      ) }}
+      {{- $existingOpencost := $opencostValues.opencost | default dict }}
+      {{- $_ := set $existingOpencost "nodeSelector" $state.nodePool.nodeSelector }}
+      {{- $_ := set $existingOpencost "tolerations" $state.nodePool.tolerations }}
+      {{- $_ := set $opencostValues "opencost" $existingOpencost }}
       {{- $_ := set $alloyMetrics "controller" (dict "nodeSelector" $state.nodePool.nodeSelector "tolerations" $state.nodePool.tolerations) }}
       {{- $_ := set $alloySingleton "controller" (dict "nodeSelector" $state.nodePool.nodeSelector "tolerations" $state.nodePool.tolerations) }}
       {{- $_ := set $alloyOperator "nodeSelector" $state.nodePool.nodeSelector }}
       {{- $_ := set $alloyOperator "tolerations" $state.nodePool.tolerations }}
     {{- end }}
-    {{- if $state.spotFeed.enabled }}
-      {{- $costModel := dict
-        "awsSpotDataBucket" $state.spotFeed.bucketName
-        "awsSpotDataRegion" $state.spotFeed.region
-        "projectID" $state.spotFeed.accountId
-        "spotLabel" "karpenter.sh/capacity-type"
-        "spotLabelValue" "spot"
-      }}
+    {{- $enableCustomPricing := or $state.spotFeed.enabled $state.cloudCosts.enabled }}
+    {{- if $enableCustomPricing }}
+      {{- $costModel := dict }}
+      {{- if $state.cloudCosts.enabled }}
+        {{- $_ := set $costModel "athenaBucketName" (printf "s3://%s/athena-results" $state.cloudCosts.bucketName) }}
+        {{- $_ := set $costModel "athenaRegion" $state.cloudCosts.region }}
+        {{- $_ := set $costModel "athenaDatabase" $state.cloudCosts.databaseName }}
+        {{- $_ := set $costModel "athenaTable" $state.cloudCosts.tableName }}
+        {{- $_ := set $costModel "athenaWorkgroup" $state.cloudCosts.workgroupName }}
+        {{- $_ := set $costModel "projectID" $state.cloudCosts.accountId }}
+      {{- end }}
+      {{- if $state.spotFeed.enabled }}
+        {{- $_ := set $costModel "awsSpotDataBucket" $state.spotFeed.bucketName }}
+        {{- $_ := set $costModel "awsSpotDataRegion" $state.spotFeed.region }}
+        {{- if not (hasKey $costModel "projectID") }}
+          {{- $_ := set $costModel "projectID" $state.spotFeed.accountId }}
+        {{- end }}
+        {{- $_ := set $costModel "spotLabel" "karpenter.sh/capacity-type" }}
+        {{- $_ := set $costModel "spotLabelValue" "spot" }}
+      {{- end }}
       {{- if $state.spotFeed.prefix }}
         {{- $_ := set $costModel "awsSpotDataPrefix" $state.spotFeed.prefix }}
       {{- end }}
@@ -79,6 +95,12 @@ spec:
         "provider" "aws"
         "costModel" $costModel
       ) }}
+      {{- $_ := set $opencostValues "opencost" $existingOpencost }}
+    {{- end }}
+    {{- if $state.cloudCosts.enabled }}
+      {{- $existingOpencost := $opencostValues.opencost | default dict }}
+      {{- $_ := set $existingOpencost "cloudCost" (dict "enabled" true) }}
+      {{- $_ := set $existingOpencost "cloudIntegrationSecret" $state.cloudCosts.secretName }}
       {{- $_ := set $opencostValues "opencost" $existingOpencost }}
     {{- end }}
     {{- if $state.prettyNames }}

--- a/functions/render/230-k8s-monitoring.yaml.gotmpl
+++ b/functions/render/230-k8s-monitoring.yaml.gotmpl
@@ -30,6 +30,8 @@ spec:
     values:
       {{- toYaml $k8sMon.overrideAllValues | nindent 6 }}
     {{- else }}
+    {{- /* Pin OpenCost to a version where missing RI data is logged as WARN instead of ERR. */}}
+    {{- $opencostImageTag := "1.120.0" }}
     {{- /* OpenCost values — deployment, gets nodeSelector + tolerations */}}
     {{- $opencostValues := dict
       "enabled" true
@@ -37,12 +39,17 @@ spec:
       "opencost" (dict
         "exporter" (dict
           "defaultClusterId" $state.clusterName
+          "image" (dict "tag" $opencostImageTag)
           "extraEnv" (dict
             "CLOUD_COST_CONFIG_PATH" "/var/configs/cloud-integration/cloud-integration.json"
+            "PLUGIN_CONFIG_DIR" "/var/configs"
           )
         )
         "prometheus" (dict "external" (dict "url" (printf "http://%s.%s:9090" $kps.prometheusServiceName $kps.namespace)))
-        "ui" (dict "enabled" true)
+        "ui" (dict
+          "enabled" true
+          "image" (dict "tag" $opencostImageTag)
+        )
       )
     }}
     {{- /* DaemonSets (alloy-logs, alloy-receiver) tolerate ALL taints so they run on
@@ -76,12 +83,16 @@ spec:
         {{- $_ := set $costModel "athenaTable" $state.cloudCosts.tableName }}
         {{- $_ := set $costModel "athenaWorkgroup" $state.cloudCosts.workgroupName }}
         {{- $_ := set $costModel "projectID" $state.cloudCosts.accountId }}
+        {{- $_ := set $costModel "athenaProjectID" $state.cloudCosts.accountId }}
       {{- end }}
       {{- if $state.spotFeed.enabled }}
         {{- $_ := set $costModel "awsSpotDataBucket" $state.spotFeed.bucketName }}
         {{- $_ := set $costModel "awsSpotDataRegion" $state.spotFeed.region }}
         {{- if not (hasKey $costModel "projectID") }}
           {{- $_ := set $costModel "projectID" $state.spotFeed.accountId }}
+        {{- end }}
+        {{- if not (hasKey $costModel "athenaProjectID") }}
+          {{- $_ := set $costModel "athenaProjectID" $state.spotFeed.accountId }}
         {{- end }}
         {{- $_ := set $costModel "spotLabel" "karpenter.sh/capacity-type" }}
         {{- $_ := set $costModel "spotLabelValue" "spot" }}

--- a/functions/render/295-opencost-cloud-integration.yaml.gotmpl
+++ b/functions/render/295-opencost-cloud-integration.yaml.gotmpl
@@ -1,0 +1,39 @@
+# code: language=yaml
+#
+# Cloud integration secret for OpenCost (CUR/Athena)
+# Wired into the k8s-monitoring chart's OpenCost subchart via cloudIntegrationSecret.
+#
+# Only rendered when cloudCosts is enabled.
+#
+
+{{- if $state.cloudCosts.enabled }}
+{{- $cloudIntegrationJSON := printf "{\"aws\":{\"athena\":[{\"bucket\":%q,\"region\":%q,\"database\":%q,\"table\":%q,\"workgroup\":%q,\"account\":%q}]}}" (printf "s3://%s/athena-results" $state.cloudCosts.bucketName) $state.cloudCosts.region $state.cloudCosts.databaseName $state.cloudCosts.tableName $state.cloudCosts.workgroupName $state.cloudCosts.accountId }}
+
+# ==============================================================================
+# Secret with Athena connection details
+# ==============================================================================
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-cloud-integration-secret
+  annotations:
+    {{ setResourceNameAnnotation "cloud-integration-secret" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{ $state.cloudCosts.secretName }}
+        namespace: {{ $state.namespace }}
+      type: Opaque
+      data:
+        cloud-integration.json: {{ $cloudIntegrationJSON | b64enc | quote }}
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+
+{{- end }}

--- a/functions/render/295-opencost-cloud-integration.yaml.gotmpl
+++ b/functions/render/295-opencost-cloud-integration.yaml.gotmpl
@@ -32,7 +32,7 @@ spec:
       kind: Secret
       metadata:
         name: {{ $state.cloudCosts.secretName }}
-        namespace: {{ $state.namespace }}
+        namespace: {{ $state.k8sMonitoring.namespace }}
       type: Opaque
       data:
         cloud-integration.json: {{ $cloudIntegrationJSON | b64enc | quote }}

--- a/functions/render/295-opencost-cloud-integration.yaml.gotmpl
+++ b/functions/render/295-opencost-cloud-integration.yaml.gotmpl
@@ -7,7 +7,11 @@
 #
 
 {{- if $state.cloudCosts.enabled }}
-{{- $cloudIntegrationJSON := printf "{\"aws\":{\"athena\":[{\"bucket\":%q,\"region\":%q,\"database\":%q,\"table\":%q,\"workgroup\":%q,\"account\":%q}]}}" (printf "s3://%s/athena-results" $state.cloudCosts.bucketName) $state.cloudCosts.region $state.cloudCosts.databaseName $state.cloudCosts.tableName $state.cloudCosts.workgroupName $state.cloudCosts.accountId }}
+{{- /*
+     Use OpenCost's legacy flat AWS array format here.
+     The chart still documents this shape, and it works across both 1.117.x and 1.120.x.
+*/}}
+{{- $cloudIntegrationJSON := printf "{\"aws\":[{\"athenaBucketName\":%q,\"athenaRegion\":%q,\"athenaDatabase\":%q,\"athenaTable\":%q,\"athenaWorkgroup\":%q,\"projectID\":%q}]}" (printf "s3://%s/athena-results" $state.cloudCosts.bucketName) $state.cloudCosts.region $state.cloudCosts.databaseName $state.cloudCosts.tableName $state.cloudCosts.workgroupName $state.cloudCosts.accountId }}
 
 # ==============================================================================
 # Secret with Athena connection details

--- a/functions/render/300-opencost-pod-identity.yaml.gotmpl
+++ b/functions/render/300-opencost-pod-identity.yaml.gotmpl
@@ -83,6 +83,57 @@ spec:
           ]
         }
   {{- end }}
+  {{- if $state.cloudCosts.enabled }}
+    - name: opencost-cloud-costs-athena
+      policy: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AthenaQueryAccess",
+              "Effect": "Allow",
+              "Action": [
+                "athena:StartQueryExecution",
+                "athena:GetQueryExecution",
+                "athena:GetQueryResults"
+              ],
+              "Resource": "arn:aws:athena:{{ $state.cloudCosts.region }}:{{ $state.cloudCosts.accountId }}:workgroup/{{ $state.cloudCosts.workgroupName }}"
+            },
+            {
+              "Sid": "GlueCatalogAccess",
+              "Effect": "Allow",
+              "Action": [
+                "glue:GetDatabase",
+                "glue:GetTable",
+                "glue:GetPartitions"
+              ],
+              "Resource": [
+                "arn:aws:glue:{{ $state.cloudCosts.region }}:{{ $state.cloudCosts.accountId }}:catalog",
+                "arn:aws:glue:{{ $state.cloudCosts.region }}:{{ $state.cloudCosts.accountId }}:database/{{ $state.cloudCosts.databaseName }}",
+                "arn:aws:glue:{{ $state.cloudCosts.region }}:{{ $state.cloudCosts.accountId }}:table/{{ $state.cloudCosts.databaseName }}/*"
+              ]
+            },
+            {
+              "Sid": "S3CURBucketRead",
+              "Effect": "Allow",
+              "Action": ["s3:GetBucketLocation", "s3:ListBucket", "s3:ListBucketMultipartUploads", "s3:HeadBucket"],
+              "Resource": "arn:aws:s3:::{{ $state.cloudCosts.bucketName }}"
+            },
+            {
+              "Sid": "S3CURDataRead",
+              "Effect": "Allow",
+              "Action": ["s3:GetObject", "s3:HeadObject", "s3:ListMultipartUploadParts", "s3:AbortMultipartUpload"],
+              "Resource": "arn:aws:s3:::{{ $state.cloudCosts.bucketName }}/*"
+            },
+            {
+              "Sid": "S3AthenaResultsWrite",
+              "Effect": "Allow",
+              "Action": ["s3:PutObject", "s3:GetObject", "s3:ListMultipartUploadParts", "s3:AbortMultipartUpload"],
+              "Resource": "arn:aws:s3:::{{ $state.cloudCosts.bucketName }}/athena-results/*"
+            }
+          ]
+        }
+  {{- end }}
   tags: {{ $state.aws.tags | toJson }}
 
 # ==============================================================================

--- a/tests/test-render/main.k
+++ b/tests/test-render/main.k
@@ -2264,7 +2264,7 @@ _items = [
                         cloudCost = {
                             enabled = True
                         }
-                        cloudIntegrationSecret = "observe-cloud-integration"
+                        cloudIntegrationSecret = "opencost-cloud-integration"
                         customPricing = {
                             enabled = True
                             provider = "aws"
@@ -2302,7 +2302,7 @@ _items = [
                         apiVersion = "v1"
                         kind = "Secret"
                         metadata = {
-                            name = "observe-cloud-integration"
+                            name = "opencost-cloud-integration"
                             namespace = "monitoring"
                         }
                         data = {
@@ -2329,6 +2329,60 @@ _items = [
     }
 
     # ==========================================================================
+    # Test: Cloud integration secret follows the k8s-monitoring namespace
+    # ==========================================================================
+    metav1alpha1.CompositionTest {
+        metadata.name = "cloud-costs-secret-uses-k8s-monitoring-namespace"
+        spec = {
+            compositionPath = "apis/observestacks/composition.yaml"
+            xrdPath = "apis/observestacks/definition.yaml"
+            timeoutSeconds = 60
+            validate = False
+            xr = {
+                apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                kind = "ObserveStack"
+                metadata.name = "observe"
+                spec = {
+                    clusterName = "my-cluster"
+                    namespace = "observability"
+                    aws.region = "us-east-2"
+                    k8sMonitoring.namespace = "cost-monitoring"
+                    cloudCosts = {
+                        enabled = True
+                        bucketName = "my-account-cur"
+                        accountId = "123456789012"
+                        region = "us-east-2"
+                        databaseName = "my_account_cur"
+                        tableName = "my_account_cur"
+                        workgroupName = "my-account-cur-workgroup"
+                    }
+                }
+            }
+            assertResources = [
+                {
+                    apiVersion = "helm.m.crossplane.io/v1beta1"
+                    kind = "Release"
+                    metadata.name = "k8s-monitoring"
+                    spec.forProvider.namespace = "cost-monitoring"
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-cloud-integration-secret"
+                    spec.forProvider.manifest = {
+                        apiVersion = "v1"
+                        kind = "Secret"
+                        metadata = {
+                            name = "opencost-cloud-integration"
+                            namespace = "cost-monitoring"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+    # ==========================================================================
     # Test: CostReport reference derives cloud cost integration values
     # ==========================================================================
     metav1alpha1.CompositionTest {
@@ -2347,6 +2401,7 @@ _items = [
                     clusterName = "my-cluster"
                     aws.region = "us-east-2"
                     cloudCosts = {
+                        enabled = True
                         costReportRef = {
                             enabled = True
                             name = "hops-root-account"
@@ -2365,7 +2420,7 @@ _items = [
                         cloudCost = {
                             enabled = True
                         }
-                        cloudIntegrationSecret = "observe-cloud-integration"
+                        cloudIntegrationSecret = "opencost-cloud-integration"
                         customPricing = {
                             enabled = True
                             provider = "aws"
@@ -2403,7 +2458,7 @@ _items = [
                         apiVersion = "v1"
                         kind = "Secret"
                         metadata = {
-                            name = "observe-cloud-integration"
+                            name = "opencost-cloud-integration"
                             namespace = "monitoring"
                         }
                         data = {

--- a/tests/test-render/main.k
+++ b/tests/test-render/main.k
@@ -2225,6 +2225,222 @@ _items = [
             ]
         }
     }
+
+    # ==========================================================================
+    # Test: Cloud costs enabled wires OpenCost Helm values, secret, and IAM
+    # ==========================================================================
+    metav1alpha1.CompositionTest {
+        metadata.name = "cloud-costs-enabled-wires-opencost"
+        spec = {
+            compositionPath = "apis/observestacks/composition.yaml"
+            xrdPath = "apis/observestacks/definition.yaml"
+            timeoutSeconds = 60
+            validate = False
+            xr = {
+                apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                kind = "ObserveStack"
+                metadata.name = "observe"
+                spec = {
+                    clusterName = "my-cluster"
+                    aws.region = "us-east-2"
+                    cloudCosts = {
+                        enabled = True
+                        bucketName = "my-account-cur"
+                        accountId = "123456789012"
+                        region = "us-east-2"
+                        databaseName = "my_account_cur"
+                        tableName = "my_account_cur"
+                        workgroupName = "my-account-cur-workgroup"
+                    }
+                }
+            }
+            assertResources = [
+                # OpenCost Helm values should use the native cloudIntegrationSecret wiring
+                {
+                    apiVersion = "helm.m.crossplane.io/v1beta1"
+                    kind = "Release"
+                    metadata.name = "k8s-monitoring"
+                    spec.forProvider.values.clusterMetrics.opencost.opencost = {
+                        cloudCost = {
+                            enabled = True
+                        }
+                        cloudIntegrationSecret = "observe-cloud-integration"
+                        customPricing = {
+                            enabled = True
+                            provider = "aws"
+                            costModel = {
+                                athenaBucketName = "s3://my-account-cur/athena-results"
+                                athenaRegion = "us-east-2"
+                                athenaDatabase = "my_account_cur"
+                                athenaTable = "my_account_cur"
+                                athenaWorkgroup = "my-account-cur-workgroup"
+                                projectID = "123456789012"
+                            }
+                        }
+                        exporter = {
+                            extraEnv = {
+                                CLOUD_COST_CONFIG_PATH = "/var/configs/cloud-integration/cloud-integration.json"
+                            }
+                        }
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-cloud-integration-secret"
+                    spec.forProvider.manifest = {
+                        apiVersion = "v1"
+                        kind = "Secret"
+                        metadata = {
+                            name = "observe-cloud-integration"
+                            namespace = "monitoring"
+                        }
+                        data = {
+                            "cloud-integration.json" = "eyJhd3MiOnsiYXRoZW5hIjpbeyJidWNrZXQiOiJzMzovL215LWFjY291bnQtY3VyL2F0aGVuYS1yZXN1bHRzIiwicmVnaW9uIjoidXMtZWFzdC0yIiwiZGF0YWJhc2UiOiJteV9hY2NvdW50X2N1ciIsInRhYmxlIjoibXlfYWNjb3VudF9jdXIiLCJ3b3JrZ3JvdXAiOiJteS1hY2NvdW50LWN1ci13b3JrZ3JvdXAiLCJhY2NvdW50IjoiMTIzNDU2Nzg5MDEyIn1dfX0="
+                        }
+                    }
+                }
+                # PodIdentity should have Athena IAM policy
+                {
+                    apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                    kind = "PodIdentity"
+                    metadata.name = "observe-opencost-pod-identity"
+                    spec.inlinePolicy = [
+                        {
+                            name = "opencost-billing"
+                        }
+                        {
+                            name = "opencost-cloud-costs-athena"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+    # ==========================================================================
+    # Test: CostReport reference derives cloud cost integration values
+    # ==========================================================================
+    metav1alpha1.CompositionTest {
+        metadata.name = "cloud-costs-cost-report-ref-derives-values"
+        spec = {
+            compositionPath = "apis/observestacks/composition.yaml"
+            xrdPath = "apis/observestacks/definition.yaml"
+            timeoutSeconds = 60
+            validate = False
+            xr = {
+                apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                kind = "ObserveStack"
+                metadata.name = "observe"
+                metadata.namespace = "default"
+                spec = {
+                    clusterName = "my-cluster"
+                    aws.region = "us-east-2"
+                    cloudCosts = {
+                        costReportRef = {
+                            enabled = True
+                            name = "hops-root-account"
+                            accountId = "123456789012"
+                            region = "us-east-2"
+                        }
+                    }
+                }
+            }
+            assertResources = [
+                {
+                    apiVersion = "helm.m.crossplane.io/v1beta1"
+                    kind = "Release"
+                    metadata.name = "k8s-monitoring"
+                    spec.forProvider.values.clusterMetrics.opencost.opencost = {
+                        cloudCost = {
+                            enabled = True
+                        }
+                        cloudIntegrationSecret = "observe-cloud-integration"
+                        customPricing = {
+                            enabled = True
+                            provider = "aws"
+                            costModel = {
+                                athenaBucketName = "s3://hops-root-account-cur/athena-results"
+                                athenaRegion = "us-east-2"
+                                athenaDatabase = "hops_root_account_cur"
+                                athenaTable = "hops_root_account_cur"
+                                athenaWorkgroup = "hops-root-account-cur-workgroup"
+                                projectID = "123456789012"
+                            }
+                        }
+                        exporter = {
+                            extraEnv = {
+                                CLOUD_COST_CONFIG_PATH = "/var/configs/cloud-integration/cloud-integration.json"
+                            }
+                        }
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-cloud-integration-secret"
+                    spec.forProvider.manifest = {
+                        apiVersion = "v1"
+                        kind = "Secret"
+                        metadata = {
+                            name = "observe-cloud-integration"
+                            namespace = "monitoring"
+                        }
+                        data = {
+                            "cloud-integration.json" = "eyJhd3MiOnsiYXRoZW5hIjpbeyJidWNrZXQiOiJzMzovL2hvcHMtcm9vdC1hY2NvdW50LWN1ci9hdGhlbmEtcmVzdWx0cyIsInJlZ2lvbiI6InVzLWVhc3QtMiIsImRhdGFiYXNlIjoiaG9wc19yb290X2FjY291bnRfY3VyIiwidGFibGUiOiJob3BzX3Jvb3RfYWNjb3VudF9jdXIiLCJ3b3JrZ3JvdXAiOiJob3BzLXJvb3QtYWNjb3VudC1jdXItd29ya2dyb3VwIiwiYWNjb3VudCI6IjEyMzQ1Njc4OTAxMiJ9XX19"
+                        }
+                    }
+                }
+                {
+                    apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                    kind = "PodIdentity"
+                    metadata.name = "observe-opencost-pod-identity"
+                    spec.inlinePolicy = [
+                        {
+                            name = "opencost-billing"
+                        }
+                        {
+                            name = "opencost-cloud-costs-athena"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+    # ==========================================================================
+    # Test: Cloud costs disabled (default) — no secret, no Athena IAM
+    # ==========================================================================
+    metav1alpha1.CompositionTest {
+        metadata.name = "cloud-costs-disabled-no-secret"
+        spec = {
+            compositionPath = "apis/observestacks/composition.yaml"
+            xrdPath = "apis/observestacks/definition.yaml"
+            timeoutSeconds = 60
+            validate = False
+            xr = {
+                apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                kind = "ObserveStack"
+                metadata.name = "observe"
+                spec = {
+                    clusterName = "my-cluster"
+                    aws.region = "us-east-1"
+                }
+            }
+            assertResources = [
+                {
+                    apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                    kind = "PodIdentity"
+                    metadata.name = "observe-opencost-pod-identity"
+                    spec.inlinePolicy = [
+                        {
+                            name = "opencost-billing"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
 ]
 
 items = _items

--- a/tests/test-render/main.k
+++ b/tests/test-render/main.k
@@ -2274,12 +2274,22 @@ _items = [
                                 athenaDatabase = "my_account_cur"
                                 athenaTable = "my_account_cur"
                                 athenaWorkgroup = "my-account-cur-workgroup"
+                                athenaProjectID = "123456789012"
                                 projectID = "123456789012"
                             }
                         }
                         exporter = {
+                            image = {
+                                tag = "1.120.0"
+                            }
                             extraEnv = {
                                 CLOUD_COST_CONFIG_PATH = "/var/configs/cloud-integration/cloud-integration.json"
+                                PLUGIN_CONFIG_DIR = "/var/configs"
+                            }
+                        }
+                        ui = {
+                            image = {
+                                tag = "1.120.0"
                             }
                         }
                     }
@@ -2296,7 +2306,7 @@ _items = [
                             namespace = "monitoring"
                         }
                         data = {
-                            "cloud-integration.json" = "eyJhd3MiOnsiYXRoZW5hIjpbeyJidWNrZXQiOiJzMzovL215LWFjY291bnQtY3VyL2F0aGVuYS1yZXN1bHRzIiwicmVnaW9uIjoidXMtZWFzdC0yIiwiZGF0YWJhc2UiOiJteV9hY2NvdW50X2N1ciIsInRhYmxlIjoibXlfYWNjb3VudF9jdXIiLCJ3b3JrZ3JvdXAiOiJteS1hY2NvdW50LWN1ci13b3JrZ3JvdXAiLCJhY2NvdW50IjoiMTIzNDU2Nzg5MDEyIn1dfX0="
+                            "cloud-integration.json" = "eyJhd3MiOlt7ImF0aGVuYUJ1Y2tldE5hbWUiOiJzMzovL215LWFjY291bnQtY3VyL2F0aGVuYS1yZXN1bHRzIiwiYXRoZW5hUmVnaW9uIjoidXMtZWFzdC0yIiwiYXRoZW5hRGF0YWJhc2UiOiJteV9hY2NvdW50X2N1ciIsImF0aGVuYVRhYmxlIjoibXlfYWNjb3VudF9jdXIiLCJhdGhlbmFXb3JrZ3JvdXAiOiJteS1hY2NvdW50LWN1ci13b3JrZ3JvdXAiLCJwcm9qZWN0SUQiOiIxMjM0NTY3ODkwMTIifV19"
                         }
                     }
                 }
@@ -2365,12 +2375,22 @@ _items = [
                                 athenaDatabase = "hops_root_account_cur"
                                 athenaTable = "hops_root_account_cur"
                                 athenaWorkgroup = "hops-root-account-cur-workgroup"
+                                athenaProjectID = "123456789012"
                                 projectID = "123456789012"
                             }
                         }
                         exporter = {
+                            image = {
+                                tag = "1.120.0"
+                            }
                             extraEnv = {
                                 CLOUD_COST_CONFIG_PATH = "/var/configs/cloud-integration/cloud-integration.json"
+                                PLUGIN_CONFIG_DIR = "/var/configs"
+                            }
+                        }
+                        ui = {
+                            image = {
+                                tag = "1.120.0"
                             }
                         }
                     }
@@ -2387,7 +2407,7 @@ _items = [
                             namespace = "monitoring"
                         }
                         data = {
-                            "cloud-integration.json" = "eyJhd3MiOnsiYXRoZW5hIjpbeyJidWNrZXQiOiJzMzovL2hvcHMtcm9vdC1hY2NvdW50LWN1ci9hdGhlbmEtcmVzdWx0cyIsInJlZ2lvbiI6InVzLWVhc3QtMiIsImRhdGFiYXNlIjoiaG9wc19yb290X2FjY291bnRfY3VyIiwidGFibGUiOiJob3BzX3Jvb3RfYWNjb3VudF9jdXIiLCJ3b3JrZ3JvdXAiOiJob3BzLXJvb3QtYWNjb3VudC1jdXItd29ya2dyb3VwIiwiYWNjb3VudCI6IjEyMzQ1Njc4OTAxMiJ9XX19"
+                            "cloud-integration.json" = "eyJhd3MiOlt7ImF0aGVuYUJ1Y2tldE5hbWUiOiJzMzovL2hvcHMtcm9vdC1hY2NvdW50LWN1ci9hdGhlbmEtcmVzdWx0cyIsImF0aGVuYVJlZ2lvbiI6InVzLWVhc3QtMiIsImF0aGVuYURhdGFiYXNlIjoiaG9wc19yb290X2FjY291bnRfY3VyIiwiYXRoZW5hVGFibGUiOiJob3BzX3Jvb3RfYWNjb3VudF9jdXIiLCJhdGhlbmFXb3JrZ3JvdXAiOiJob3BzLXJvb3QtYWNjb3VudC1jdXItd29ya2dyb3VwIiwicHJvamVjdElEIjoiMTIzNDU2Nzg5MDEyIn1dfQ=="
                         }
                     }
                 }

--- a/upbound.yaml
+++ b/upbound.yaml
@@ -25,7 +25,8 @@ spec:
     package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3
     version: '>=v2'
   description: Deploys a complete observability stack (Prometheus, Loki, Tempo, k8s-monitoring,
-    Grafana) with AWS Pod Identity and S3 storage support.
+    Grafana) with AWS Pod Identity, CostReport-aware OpenCost cloud cost integration,
+    and S3 storage support.
   license: Apache-2.0
   maintainer: Patrick Lee Scott <pat@patscott.io>
   readme: |
@@ -34,6 +35,7 @@ spec:
     Deploys a complete observability stack with correct deletion ordering.
     Composes kube-prometheus-stack, Loki, Tempo, k8s-monitoring, Grafana Operator,
     and Grafana datasources/dashboards as direct Helm releases, with AWS Pod Identity
-    for OpenCost billing access and optional S3 storage for Loki and Tempo.
+    for OpenCost billing access, support for separately managed CostReport CUR/Athena
+    inputs, and optional S3 storage for Loki and Tempo.
   repository: ghcr.io/hops-ops/aws-observe-stack
   source: github.com/hops-ops/aws-observe-stack


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS CUR/Athena cloud cost integration for tracking AWS spend and feeding OpenCost
  * Optional CostReport reference to centralize cloud cost configuration and derive CUR/Athena naming
  * OpenCost values now enable cloud ingestion and create the cloud-integration secret plus required runtime permissions

* **Documentation**
  * Added Cloud Costs configuration guide with a YAML example

* **Examples**
  * Added a sample ObserveStack manifest demonstrating cloudCosts + CostReport usage

* **Tests**
  * Added render tests validating cloudCosts rendering and OpenCost integration

* **Chores**
  * CI/Make targets updated to include the new example in render/validate runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->