### PR TITLE
feat: public exposure surface (oauth2-proxy + Zitadel OIDC + ext_authz)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ EXAMPLES := \
     examples/observestacks/cloud-costs.yaml:: \
     examples/observestacks/nodepool.yaml:: \
     examples/observestacks/spot-feed.yaml:: \
-    examples/observestacks/metrics-server.yaml::
+    examples/observestacks/metrics-server.yaml:: \
+    examples/observestacks/exposure.yaml::
 
 # Render all examples (parallel execution, output shown per-job when complete)
 render\:all:

--- a/apis/observestacks/definition.yaml
+++ b/apis/observestacks/definition.yaml
@@ -821,6 +821,68 @@ spec:
                         additionalProperties:
                           type: string
                         x-kubernetes-preserve-unknown-fields: true
+                  grafana:
+                    description: |
+                      Public exposure for Grafana with app-level OIDC (Grafana speaks OIDC
+                      natively — per `feedback_app_level_oidc`, app-level integration beats
+                      proxy-trust for refresh tokens, sign-out, WebSocket auth). Composes
+                      a dedicated Zitadel OIDC Application and wires Grafana Helm values
+                      under spec.kubePrometheusStack.values.grafana — no AuthorizationPolicy.CUSTOM
+                      gate, Grafana enforces auth itself.
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                        default: false
+                      host:
+                        description: Hostname for the HTTPRoute (e.g., "grafana.ops.com.ai").
+                        type: string
+                      serviceName:
+                        description: Upstream Grafana Service name. Defaults to "grafana" (kube-prometheus-stack chart's default).
+                        type: string
+                        default: grafana
+                      servicePort:
+                        description: Upstream Grafana Service port. Defaults to 80.
+                        type: integer
+                        default: 80
+                      podSelector:
+                        description: Selector for Grafana pods. Defaults to stock kube-prometheus-stack chart labels.
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-kubernetes-preserve-unknown-fields: true
+                      allowedDomains:
+                        description: Email-domain allow-list. Maps to grafana.ini auth.generic_oauth.allowed_domains (comma-joined).
+                        type: array
+                        items:
+                          type: string
+                      roleAttributePath:
+                        description: JMESPath against the ID token to map to a Grafana role (Admin, Editor, Viewer). Example -contains("urn:zitadel:iam:org:project:roles", "observe-admin") && "Admin" || "Viewer"-.
+                        type: string
+                      maxSessionDuration:
+                        description: Grafana session lifetime (auth.login_maximum_lifetime_duration). Defaults to 8h.
+                        type: string
+                        default: "8h"
+                      tokenRotationMinutes:
+                        description: Grafana token rotation interval (auth.token_rotation_interval_minutes). Defaults to 10.
+                        type: integer
+                        default: 10
+                      useRefreshToken:
+                        description: Whether to use OIDC refresh tokens (auth.generic_oauth.use_refresh_token). Defaults to true.
+                        type: boolean
+                        default: true
+                      autoLogin:
+                        description: Auto-redirect to Zitadel on first page load (auth.oauth_auto_login). Defaults to false to avoid surprise redirects.
+                        type: boolean
+                        default: false
+                      orgAttributePath:
+                        description: Optional JMESPath for org assignment (auth.generic_oauth.org_attribute_path).
+                        type: string
+                      orgMapping:
+                        description: Optional org mapping list (auth.generic_oauth.org_mapping, comma-joined).
+                        type: array
+                        items:
+                          type: string
             required:
             - clusterName
             - aws
@@ -878,6 +940,18 @@ spec:
                       url:
                         type: string
                       ready:
+                        type: boolean
+                  grafana:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      url:
+                        type: string
+                      ready:
+                        type: boolean
+                      oidcClientReady:
+                        description: True when the dedicated Grafana Zitadel OIDC Application MR is Ready.
                         type: boolean
         required:
         - spec

--- a/apis/observestacks/definition.yaml
+++ b/apis/observestacks/definition.yaml
@@ -613,6 +613,210 @@ spec:
                   workgroupName:
                     description: "Manual fallback: Athena workgroup name. Required when cloudCosts.enabled is true and cloudCosts.costReportRef.enabled is not true."
                     type: string
+              auth:
+                description: |
+                  AuthStack integration. Identity-only — AuthStack publishes the OIDC issuer URL
+                  and the AWS Secrets Manager path holding the iam-admin PAT. ObserveStack composes
+                  an ExternalSecret + Zitadel ProviderConfig + Zitadel OIDC Application in its own
+                  namespace, and oauth2-proxy / Redis live with it. No data-path coupling to AuthStack.
+                  See specs/platform-public-exposure.
+                type: object
+                properties:
+                  authStackRef:
+                    description: Reference to the AuthStack XR that publishes the OIDC issuer + AWS SM credentials path. Currently informational — operator wires up the actual fields below.
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                  issuerURL:
+                    description: Zitadel issuer URL (host portion of status.oidc.issuerURL from AuthStack), e.g., https://auth.ops.com.ai.
+                    type: string
+                  zitadelDomain:
+                    description: Zitadel domain (host only) for the embedded ProviderConfig credentials JSON. Defaults to the host of issuerURL.
+                    type: string
+                  awsSecretsManagerPath:
+                    description: AWS Secrets Manager key holding the iam-admin PAT (AuthStack status.providerConfig.awsSecretsManagerPath). Typical shape "push/<cluster>/zitadel-credentials".
+                    type: string
+                  accessTokenProperty:
+                    description: Property within the AWS SM JSON to extract for the PAT. Defaults to "access_token".
+                    type: string
+                    default: access_token
+                  zitadelProjectId:
+                    description: Zitadel project ID where ObserveStack creates the oauth2-proxy OIDC application. Operator-provided — AuthStack does not compose Zitadel Projects.
+                    type: string
+              exposure:
+                description: |
+                  Public exposure of observe-stack dashboards behind an OIDC-aware oauth2-proxy
+                  bridge per specs/platform-public-exposure. The bridge lives in the observe
+                  namespace, registers as an ext_authz provider on IstioStack, and gates per-
+                  component HTTPRoutes via AuthorizationPolicy.CUSTOM. Grafana app-level OIDC
+                  is a sibling task (observe-stack-grafana-oidc) and not covered here.
+                type: object
+                properties:
+                  enabled:
+                    description: Whether to compose the exposure bridge + per-component HTTPRoutes/policies. Defaults to false.
+                    type: boolean
+                    default: false
+                  domain:
+                    description: Exposure domain (e.g., "observe.ops.com.ai" or "ops.com.ai"). Cookie domain + Certificate dnsName + HTTPRoute host suffix are derived from this. Required when enabled is true.
+                    type: string
+                  gatewayRef:
+                    description: Gateway API parentRef the per-host HTTPRoutes attach to. Defaults to istio-ingress/platform/http.
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        default: platform
+                      namespace:
+                        type: string
+                        default: istio-ingress
+                      sectionName:
+                        description: Listener name (HTTP for port 80, https-apex for the HTTPS apex listener, etc.). Defaults to http.
+                        type: string
+                        default: http
+                  extensionProviderName:
+                    description: Name to register with IstioStack spec.extensionProviders[].name. Convention is <stack-namespace>-oauth2-proxy. Defaults to "<observe-namespace>-oauth2-proxy".
+                    type: string
+                  certificate:
+                    description: Wildcard TLS certificate composition via cert-manager. Skip when the exposure domain is already covered by an existing wildcard certificate at the Gateway.
+                    type: object
+                    properties:
+                      enabled:
+                        description: Whether to compose a cert-manager Certificate resource. Defaults to false (assume the Gateway's wildcard listener already covers exposure.domain).
+                        type: boolean
+                        default: false
+                      issuerRef:
+                        description: cert-manager Issuer / ClusterIssuer reference.
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            default: cloudflare-cluster-issuer
+                          kind:
+                            type: string
+                            enum:
+                            - Issuer
+                            - ClusterIssuer
+                            default: ClusterIssuer
+                      secretName:
+                        description: K8s Secret name for the issued cert. Defaults to "<observe-namespace>-exposure-tls".
+                        type: string
+                      secretNamespace:
+                        description: Namespace for the issued cert Secret. Defaults to istio-ingress so the platform Gateway HTTPS listener can reference it.
+                        type: string
+                        default: istio-ingress
+                  redis:
+                    description: oauth2-proxy session backend (single-replica Redis with PVC). Sessions are disposable — Pod restart forces re-login, which is acceptable.
+                    type: object
+                    properties:
+                      size:
+                        description: PVC size for the Redis StatefulSet. Defaults to 1Gi.
+                        type: string
+                        default: 1Gi
+                      storageClassName:
+                        description: StorageClass for the Redis PVC. Defaults to the cluster's default.
+                        type: string
+                      image:
+                        description: Redis container image. Defaults to "redis:7-alpine".
+                        type: string
+                        default: redis:7-alpine
+                  oauth2Proxy:
+                    description: oauth2-proxy bridge configuration.
+                    type: object
+                    properties:
+                      image:
+                        description: oauth2-proxy container image. Defaults to "quay.io/oauth2-proxy/oauth2-proxy:v7.7.1".
+                        type: string
+                        default: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
+                      replicas:
+                        description: oauth2-proxy Deployment replicas. Defaults to 1.
+                        type: integer
+                        default: 1
+                      additionalConfig:
+                        description: Additional oauth2-proxy CLI flags to append (e.g., "--whitelist-domain=*.observe.ops.com.ai"). One flag per list entry.
+                        type: array
+                        items:
+                          type: string
+                      cookieDomain:
+                        description: Cookie domain (e.g., ".observe.ops.com.ai"). Defaults to ".<exposure.domain>".
+                        type: string
+                      cookieSecretRef:
+                        description: |
+                          Reference to a Secret in the observe namespace holding the cookie-signing key.
+                          Operator pre-creates it once -kubectl create secret generic <name> --from-literal=<key>=$(openssl rand -hex 16) -n <observe-ns>-. Required when exposure.enabled is true.
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          key:
+                            type: string
+                            default: cookie_secret
+                  prometheus:
+                    description: Public exposure for the Prometheus UI. Skips if disabled.
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                        default: false
+                      host:
+                        description: Hostname for the HTTPRoute (e.g., "prometheus.observe.ops.com.ai").
+                        type: string
+                      serviceName:
+                        description: Upstream service name (kube-prometheus-stack-prometheus). Defaults to "kube-prometheus-stack-prometheus". Kept for backward compatibility; the composition routes through a sister Service named "exposure-prometheus" that mirrors the same pods via podSelector.
+                        type: string
+                        default: kube-prometheus-stack-prometheus
+                      servicePort:
+                        description: Upstream service port. Defaults to 9090.
+                        type: integer
+                        default: 9090
+                      podSelector:
+                        description: Selector for the upstream component's pods. The composition emits a sister Service (exposure-prometheus) with this selector, labeled istio.io/use-waypoint=<observe-ns>-waypoint, so the Waypoint intercepts traffic and the AuthorizationPolicy.CUSTOM fires. Defaults match stock kube-prometheus-stack v77.x.
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-kubernetes-preserve-unknown-fields: true
+                  alertmanager:
+                    description: Public exposure for the Alertmanager UI.
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                        default: false
+                      host:
+                        type: string
+                      serviceName:
+                        type: string
+                        default: kube-prometheus-stack-alertmanager
+                      servicePort:
+                        type: integer
+                        default: 9093
+                      podSelector:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-kubernetes-preserve-unknown-fields: true
+                  opencost:
+                    description: Public exposure for the OpenCost UI.
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                        default: false
+                      host:
+                        type: string
+                      serviceName:
+                        type: string
+                        default: opencost
+                      servicePort:
+                        type: integer
+                        default: 9090
+                      podSelector:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        x-kubernetes-preserve-unknown-fields: true
             required:
             - clusterName
             - aws
@@ -623,5 +827,53 @@ spec:
               ready:
                 description: Overall readiness.
                 type: boolean
+              exposure:
+                description: Public exposure status — per-component URLs populated once HTTPRoutes are programmed and the upstream / oauth2-proxy / Redis are Ready.
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  extensionProviderName:
+                    description: Name registered with IstioStack. Operators add a matching entry to IstioStack spec.extensionProviders[] (no auto-discovery in v1).
+                    type: string
+                  cookieDomain:
+                    type: string
+                  oauth2Proxy:
+                    type: object
+                    properties:
+                      ready:
+                        type: boolean
+                      redisReady:
+                        type: boolean
+                      oidcClientReady:
+                        description: True when the Zitadel OIDC Application MR is Ready and the connection Secret has been written.
+                        type: boolean
+                  prometheus:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      url:
+                        type: string
+                      ready:
+                        type: boolean
+                  alertmanager:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      url:
+                        type: string
+                      ready:
+                        type: boolean
+                  opencost:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      url:
+                        type: string
+                      ready:
+                        type: boolean
         required:
         - spec

--- a/apis/observestacks/definition.yaml
+++ b/apis/observestacks/definition.yaml
@@ -663,7 +663,7 @@ spec:
                     description: Exposure domain (e.g., "observe.ops.com.ai" or "ops.com.ai"). Cookie domain + Certificate dnsName + HTTPRoute host suffix are derived from this. Required when enabled is true.
                     type: string
                   gatewayRef:
-                    description: Gateway API parentRef the per-host HTTPRoutes attach to. Defaults to istio-ingress/platform/http.
+                    description: Gateway API parentRef the per-host HTTPRoutes attach to. Defaults to istio-ingress/platform/[http,https-apex] so OAuth flows that redirect to HTTPS (cookie-secure=true) complete end-to-end.
                     type: object
                     properties:
                       name:
@@ -672,10 +672,14 @@ spec:
                       namespace:
                         type: string
                         default: istio-ingress
-                      sectionName:
-                        description: Listener name (HTTP for port 80, https-apex for the HTTPS apex listener, etc.). Defaults to http.
-                        type: string
-                        default: http
+                      sectionNames:
+                        description: Listener names on the parent Gateway to attach to. Each becomes a separate parentRef entry on the HTTPRoute. Defaults to [http, https-apex] which covers both initial HTTP requests and the post-OIDC callback over HTTPS.
+                        type: array
+                        items:
+                          type: string
+                        default:
+                        - http
+                        - https-apex
                   extensionProviderName:
                     description: Name to register with IstioStack spec.extensionProviders[].name. Convention is <stack-namespace>-oauth2-proxy. Defaults to "<observe-namespace>-oauth2-proxy".
                     type: string

--- a/examples/observestacks/exposure.yaml
+++ b/examples/observestacks/exposure.yaml
@@ -46,3 +46,9 @@ spec:
     opencost:
       enabled: true
       host: opencost.observe.example.com
+    grafana:
+      enabled: true
+      host: grafana.observe.example.com
+      allowedDomains:
+      - example.com
+      roleAttributePath: 'contains("urn:zitadel:iam:org:project:roles", "observe-admin") && "Admin" || "Viewer"'

--- a/examples/observestacks/exposure.yaml
+++ b/examples/observestacks/exposure.yaml
@@ -1,0 +1,48 @@
+# ObserveStack with public exposure enabled.
+#
+# Prerequisites the operator does once per cluster:
+#   1. Create a Zitadel project (UI or another stack) and note the projectId.
+#   2. Push the iam-admin PAT into AWS Secrets Manager at
+#      "push/<cluster>/zitadel-credentials" (AuthStack does this for you).
+#   3. Pre-create the cookie-signing secret in the observe namespace:
+#        kubectl create secret generic observe-oauth2-proxy-cookie \
+#          --from-literal=cookie_secret=$(openssl rand -hex 16) -n monitoring
+#   4. Register `monitoring-oauth2-proxy` as an extensionProvider on IstioStack
+#      (per tasks/istio-stack-extension-providers).
+#
+# Then apply this XR — ObserveStack composes everything else (Zitadel OIDC
+# client, ExternalSecret for the PAT, Redis, oauth2-proxy, Waypoint, sister
+# Services, HTTPRoutes, AuthorizationPolicy.CUSTOM).
+apiVersion: aws.hops.ops.com.ai/v1alpha1
+kind: ObserveStack
+metadata:
+  name: observe
+  namespace: default
+spec:
+  clusterName: my-cluster
+  namespace: monitoring
+  aws:
+    region: us-east-1
+
+  auth:
+    issuerURL: https://auth.example.com
+    awsSecretsManagerPath: push/my-cluster/zitadel-credentials
+    accessTokenProperty: access_token
+    zitadelProjectId: "330000000000000001"
+
+  exposure:
+    enabled: true
+    domain: observe.example.com
+    extensionProviderName: monitoring-oauth2-proxy
+    oauth2Proxy:
+      cookieSecretRef:
+        name: observe-oauth2-proxy-cookie
+    prometheus:
+      enabled: true
+      host: prometheus.observe.example.com
+    alertmanager:
+      enabled: true
+      host: alertmanager.observe.example.com
+    opencost:
+      enabled: true
+      host: opencost.observe.example.com

--- a/functions/render/000-state-init.yaml.gotmpl
+++ b/functions/render/000-state-init.yaml.gotmpl
@@ -241,6 +241,153 @@
 {{- end }}
 
 # ==============================================================================
+# Auth integration (Zitadel — composed via provider-upjet-zitadel)
+# ==============================================================================
+{{- $auth := $spec.auth | default dict }}
+{{- $authStackRef := $auth.authStackRef | default dict }}
+{{- $authIssuerURL := $auth.issuerURL | default "" }}
+{{- $authAwsSmPath := $auth.awsSecretsManagerPath | default "" }}
+{{- $authAccessTokenProperty := $auth.accessTokenProperty | default "access_token" }}
+{{- $authProjectId := $auth.zitadelProjectId | default "" }}
+
+{{- /* Derive zitadelDomain host from issuerURL when not explicitly set:
+   trim scheme, then trim any path. */}}
+{{- $authZitadelDomain := $auth.zitadelDomain | default "" }}
+{{- if and (eq $authZitadelDomain "") (ne $authIssuerURL "") }}
+  {{- $h := $authIssuerURL }}
+  {{- $h = $h | trimPrefix "https://" | trimPrefix "http://" }}
+  {{- $authZitadelDomain = (splitn "/" 2 $h)._0 }}
+{{- end }}
+
+# ==============================================================================
+# Exposure (public exposure via oauth2-proxy + ext_authz)
+# ==============================================================================
+{{- $exposure := $spec.exposure | default dict }}
+{{- $exposureEnabled := false }}
+{{- if hasKey $exposure "enabled" }}
+  {{- $exposureEnabled = $exposure.enabled }}
+{{- end }}
+{{- $exposureDomain := $exposure.domain | default "" }}
+
+{{- /* Validate when enabled. */}}
+{{- if $exposureEnabled }}
+  {{- if eq $exposureDomain "" }}
+    {{- fail "spec.exposure.domain is required when spec.exposure.enabled is true" }}
+  {{- end }}
+  {{- if eq $authIssuerURL "" }}
+    {{- fail "spec.auth.issuerURL is required when spec.exposure.enabled is true" }}
+  {{- end }}
+  {{- if eq $authAwsSmPath "" }}
+    {{- fail "spec.auth.awsSecretsManagerPath is required when spec.exposure.enabled is true" }}
+  {{- end }}
+  {{- if eq $authProjectId "" }}
+    {{- fail "spec.auth.zitadelProjectId is required when spec.exposure.enabled is true" }}
+  {{- end }}
+{{- end }}
+
+{{- $exposureGatewayRef := $exposure.gatewayRef | default dict }}
+{{- $exposureGatewayRef = dict
+  "name" ($exposureGatewayRef.name | default "platform")
+  "namespace" ($exposureGatewayRef.namespace | default "istio-ingress")
+  "sectionName" ($exposureGatewayRef.sectionName | default "http")
+}}
+
+{{- $exposureExtProviderName := $exposure.extensionProviderName | default (printf "%s-oauth2-proxy" $namespace) }}
+
+{{- $exposureCert := $exposure.certificate | default dict }}
+{{- $exposureCertEnabled := false }}
+{{- if hasKey $exposureCert "enabled" }}
+  {{- $exposureCertEnabled = $exposureCert.enabled }}
+{{- end }}
+{{- $exposureCertIssuerRef := $exposureCert.issuerRef | default dict }}
+{{- $exposureCertIssuerRef = dict
+  "name" ($exposureCertIssuerRef.name | default "cloudflare-cluster-issuer")
+  "kind" ($exposureCertIssuerRef.kind | default "ClusterIssuer")
+}}
+{{- $exposureCertSecretName := $exposureCert.secretName | default (printf "%s-exposure-tls" $namespace) }}
+{{- $exposureCertSecretNamespace := $exposureCert.secretNamespace | default "istio-ingress" }}
+
+{{- $exposureRedis := $exposure.redis | default dict }}
+{{- $exposureRedis = dict
+  "size" ($exposureRedis.size | default "1Gi")
+  "storageClassName" ($exposureRedis.storageClassName | default "")
+  "image" ($exposureRedis.image | default "redis:7-alpine")
+}}
+
+{{- $exposureProxy := $exposure.oauth2Proxy | default dict }}
+{{- $exposureProxyCookieDomain := $exposureProxy.cookieDomain | default (printf ".%s" $exposureDomain) }}
+{{- $exposureProxyCookieRef := $exposureProxy.cookieSecretRef | default dict }}
+{{- $exposureProxyCookieRef = dict
+  "name" ($exposureProxyCookieRef.name | default "")
+  "key" ($exposureProxyCookieRef.key | default "cookie_secret")
+}}
+{{- if and $exposureEnabled (eq $exposureProxyCookieRef.name "") }}
+  {{- fail "spec.exposure.oauth2Proxy.cookieSecretRef.name is required when spec.exposure.enabled is true (operator pre-creates the Secret holding the cookie-signing key)" }}
+{{- end }}
+{{- $exposureProxy = dict
+  "image" ($exposureProxy.image | default "quay.io/oauth2-proxy/oauth2-proxy:v7.7.1")
+  "replicas" ($exposureProxy.replicas | default 1)
+  "additionalConfig" ($exposureProxy.additionalConfig | default list)
+  "cookieDomain" $exposureProxyCookieDomain
+  "cookieSecretRef" $exposureProxyCookieRef
+}}
+
+{{- /* Waypoint name — composed by 445-* and referenced from sister Services + ext_authz provider naming. */}}
+{{- $exposureWaypointName := printf "%s-waypoint" $namespace }}
+
+{{- /* Chart-default pod selectors (kube-prometheus-stack v77.x + opencost chart conventions).
+       Operators override per cluster via spec.exposure.<comp>.podSelector when on a different chart version. */}}
+{{- $defaultPodSelectors := dict
+  "prometheus" (dict
+    "app.kubernetes.io/name" "prometheus"
+    "prometheus" "kube-prometheus-stack-prometheus"
+  )
+  "alertmanager" (dict
+    "app.kubernetes.io/name" "alertmanager"
+    "alertmanager" "kube-prometheus-stack-alertmanager"
+  )
+  "opencost" (dict
+    "app.kubernetes.io/name" "opencost"
+  )
+}}
+
+{{- $exposureComponents := list }}
+{{- range $compName := list "prometheus" "alertmanager" "opencost" }}
+  {{- $comp := get $exposure $compName | default dict }}
+  {{- $compEnabled := false }}
+  {{- if hasKey $comp "enabled" }}
+    {{- $compEnabled = $comp.enabled }}
+  {{- end }}
+  {{- $compHost := $comp.host | default "" }}
+  {{- if and $exposureEnabled $compEnabled (eq $compHost "") }}
+    {{- fail (printf "spec.exposure.%s.host is required when spec.exposure.%s.enabled is true" $compName $compName) }}
+  {{- end }}
+  {{- $compSvcName := $comp.serviceName | default "" }}
+  {{- $compSvcPort := $comp.servicePort | default 0 }}
+  {{- if eq $compName "prometheus" }}
+    {{- $compSvcName = $comp.serviceName | default "kube-prometheus-stack-prometheus" }}
+    {{- $compSvcPort = $comp.servicePort | default 9090 }}
+  {{- else if eq $compName "alertmanager" }}
+    {{- $compSvcName = $comp.serviceName | default "kube-prometheus-stack-alertmanager" }}
+    {{- $compSvcPort = $comp.servicePort | default 9093 }}
+  {{- else if eq $compName "opencost" }}
+    {{- $compSvcName = $comp.serviceName | default "opencost" }}
+    {{- $compSvcPort = $comp.servicePort | default 9090 }}
+  {{- end }}
+  {{- $defaultSel := get $defaultPodSelectors $compName | default dict }}
+  {{- $compPodSelector := $comp.podSelector | default $defaultSel }}
+  {{- $exposureComponents = append $exposureComponents (dict
+    "name" $compName
+    "enabled" $compEnabled
+    "host" $compHost
+    "serviceName" $compSvcName
+    "servicePort" $compSvcPort
+    "podSelector" $compPodSelector
+    "sisterServiceName" (printf "exposure-%s" $compName)
+  ) }}
+{{- end }}
+
+# ==============================================================================
 # Initialize $state
 # ==============================================================================
 {{- $state := dict
@@ -395,6 +542,33 @@
       "databaseName" ($cloudCostsCostReportRef.databaseName | default "")
       "workgroupName" ($cloudCostsCostReportRef.workgroupName | default "")
     )
+  )
+  "auth" (dict
+    "authStackRef" (dict
+      "name" ($authStackRef.name | default "")
+      "namespace" ($authStackRef.namespace | default "")
+    )
+    "issuerURL" $authIssuerURL
+    "zitadelDomain" $authZitadelDomain
+    "awsSecretsManagerPath" $authAwsSmPath
+    "accessTokenProperty" $authAccessTokenProperty
+    "zitadelProjectId" $authProjectId
+  )
+  "exposure" (dict
+    "enabled" $exposureEnabled
+    "domain" $exposureDomain
+    "gatewayRef" $exposureGatewayRef
+    "extensionProviderName" $exposureExtProviderName
+    "waypointName" $exposureWaypointName
+    "certificate" (dict
+      "enabled" $exposureCertEnabled
+      "issuerRef" $exposureCertIssuerRef
+      "secretName" $exposureCertSecretName
+      "secretNamespace" $exposureCertSecretNamespace
+    )
+    "redis" $exposureRedis
+    "oauth2Proxy" $exposureProxy
+    "components" $exposureComponents
   )
   "observed" (dict)
   "status" (dict)

--- a/functions/render/000-state-init.yaml.gotmpl
+++ b/functions/render/000-state-init.yaml.gotmpl
@@ -286,10 +286,11 @@
 {{- end }}
 
 {{- $exposureGatewayRef := $exposure.gatewayRef | default dict }}
+{{- $exposureGatewayRefSectionNames := $exposureGatewayRef.sectionNames | default (list "http" "https-apex") }}
 {{- $exposureGatewayRef = dict
   "name" ($exposureGatewayRef.name | default "platform")
   "namespace" ($exposureGatewayRef.namespace | default "istio-ingress")
-  "sectionName" ($exposureGatewayRef.sectionName | default "http")
+  "sectionNames" $exposureGatewayRefSectionNames
 }}
 
 {{- $exposureExtProviderName := $exposure.extensionProviderName | default (printf "%s-oauth2-proxy" $namespace) }}

--- a/functions/render/000-state-init.yaml.gotmpl
+++ b/functions/render/000-state-init.yaml.gotmpl
@@ -350,10 +350,25 @@
   "opencost" (dict
     "app.kubernetes.io/name" "opencost"
   )
+  "grafana" (dict
+    "app.kubernetes.io/name" "grafana"
+    "app.kubernetes.io/instance" "kube-prometheus-stack"
+  )
+}}
+
+{{- /* authMode discriminator per component:
+       - ext_authz: gated via AuthorizationPolicy.CUSTOM + oauth2-proxy ext_authz
+       - app_level: app speaks OIDC itself; no AuthorizationPolicy, no /oauth2/* HTTPRoute rule.
+       See feedback_app_level_oidc. */}}
+{{- $defaultAuthMode := dict
+  "prometheus" "ext_authz"
+  "alertmanager" "ext_authz"
+  "opencost" "ext_authz"
+  "grafana" "app_level"
 }}
 
 {{- $exposureComponents := list }}
-{{- range $compName := list "prometheus" "alertmanager" "opencost" }}
+{{- range $compName := list "prometheus" "alertmanager" "opencost" "grafana" }}
   {{- $comp := get $exposure $compName | default dict }}
   {{- $compEnabled := false }}
   {{- if hasKey $comp "enabled" }}
@@ -374,9 +389,13 @@
   {{- else if eq $compName "opencost" }}
     {{- $compSvcName = $comp.serviceName | default "opencost" }}
     {{- $compSvcPort = $comp.servicePort | default 9090 }}
+  {{- else if eq $compName "grafana" }}
+    {{- $compSvcName = $comp.serviceName | default "grafana" }}
+    {{- $compSvcPort = $comp.servicePort | default 80 }}
   {{- end }}
   {{- $defaultSel := get $defaultPodSelectors $compName | default dict }}
   {{- $compPodSelector := $comp.podSelector | default $defaultSel }}
+  {{- $compAuthMode := get $defaultAuthMode $compName | default "ext_authz" }}
   {{- $exposureComponents = append $exposureComponents (dict
     "name" $compName
     "enabled" $compEnabled
@@ -384,9 +403,26 @@
     "serviceName" $compSvcName
     "servicePort" $compSvcPort
     "podSelector" $compPodSelector
+    "authMode" $compAuthMode
     "sisterServiceName" (printf "exposure-%s" $compName)
   ) }}
 {{- end }}
+
+{{- /* Grafana app-level OIDC config (extracted into its own struct so the
+       Grafana Helm-values template can reference it cleanly). */}}
+{{- $exposureGrafana := $exposure.grafana | default dict }}
+{{- $exposureGrafanaCfg := dict
+  "enabled" (and $exposureEnabled (hasKey $exposureGrafana "enabled") $exposureGrafana.enabled)
+  "host" ($exposureGrafana.host | default "")
+  "allowedDomains" ($exposureGrafana.allowedDomains | default list)
+  "roleAttributePath" ($exposureGrafana.roleAttributePath | default "")
+  "maxSessionDuration" ($exposureGrafana.maxSessionDuration | default "8h")
+  "tokenRotationMinutes" ($exposureGrafana.tokenRotationMinutes | default 10)
+  "useRefreshToken" (or (not (hasKey $exposureGrafana "useRefreshToken")) $exposureGrafana.useRefreshToken)
+  "autoLogin" (and (hasKey $exposureGrafana "autoLogin") $exposureGrafana.autoLogin)
+  "orgAttributePath" ($exposureGrafana.orgAttributePath | default "")
+  "orgMapping" ($exposureGrafana.orgMapping | default list)
+}}
 
 # ==============================================================================
 # Initialize $state
@@ -570,6 +606,7 @@
     "redis" $exposureRedis
     "oauth2Proxy" $exposureProxy
     "components" $exposureComponents
+    "grafana" $exposureGrafanaCfg
   )
   "observed" (dict)
   "status" (dict)

--- a/functions/render/010-state-status.yaml.gotmpl
+++ b/functions/render/010-state-status.yaml.gotmpl
@@ -10,7 +10,7 @@
 # ==============================================================================
 
 {{- $checkReady := dict }}
-{{- range $key := list "kube-prometheus-stack" "loki" "tempo" "k8s-monitoring" "grafana-operator" "grafana-instance" "datasource-prometheus" "datasource-loki" "datasource-tempo" "opencost-pod-identity" "loki-pod-identity" "tempo-pod-identity" "vpa" "goldilocks" "nodepool-observe" }}
+{{- range $key := list "kube-prometheus-stack" "loki" "tempo" "k8s-monitoring" "grafana-operator" "grafana-instance" "datasource-prometheus" "datasource-loki" "datasource-tempo" "opencost-pod-identity" "loki-pod-identity" "tempo-pod-identity" "vpa" "goldilocks" "nodepool-observe" "exposure-zitadel-credentials" "exposure-zitadel-providerconfig" "exposure-oidc-app" "exposure-redis-sts" "exposure-oauth2-proxy-deploy" "exposure-waypoint" }}
   {{- $entry := get $observed $key | default dict }}
   {{- $resource := $entry.resource | default dict }}
   {{- $status := $resource.status | default dict }}
@@ -26,6 +26,16 @@
 # ==============================================================================
 # Set observed state
 # ==============================================================================
+{{- $exposureOauth2Ready := and
+  (get $checkReady "exposure-redis-sts")
+  (get $checkReady "exposure-oauth2-proxy-deploy")
+}}
+{{- $exposureOidcReady := and
+  (get $checkReady "exposure-zitadel-credentials")
+  (get $checkReady "exposure-zitadel-providerconfig")
+  (get $checkReady "exposure-oidc-app")
+}}
+
 {{- $state = set $state "observed" (merge $state.observed (dict
   "kubePrometheusStack" (dict "ready" (get $checkReady "kube-prometheus-stack"))
   "loki" (dict "ready" (get $checkReady "loki"))
@@ -42,6 +52,12 @@
   "vpa" (dict "ready" (get $checkReady "vpa"))
   "goldilocks" (dict "ready" (get $checkReady "goldilocks"))
   "nodepoolObserve" (dict "ready" (get $checkReady "nodepool-observe"))
+  "exposure" (dict
+    "oauth2ProxyReady" $exposureOauth2Ready
+    "redisReady" (get $checkReady "exposure-redis-sts")
+    "oidcClientReady" $exposureOidcReady
+    "waypointReady" (get $checkReady "exposure-waypoint")
+  )
 )) }}
 
 # ==============================================================================

--- a/functions/render/010-state-status.yaml.gotmpl
+++ b/functions/render/010-state-status.yaml.gotmpl
@@ -10,7 +10,7 @@
 # ==============================================================================
 
 {{- $checkReady := dict }}
-{{- range $key := list "kube-prometheus-stack" "loki" "tempo" "k8s-monitoring" "grafana-operator" "grafana-instance" "datasource-prometheus" "datasource-loki" "datasource-tempo" "opencost-pod-identity" "loki-pod-identity" "tempo-pod-identity" "vpa" "goldilocks" "nodepool-observe" "exposure-zitadel-credentials" "exposure-zitadel-providerconfig" "exposure-oidc-app" "exposure-redis-sts" "exposure-oauth2-proxy-deploy" "exposure-waypoint" }}
+{{- range $key := list "kube-prometheus-stack" "loki" "tempo" "k8s-monitoring" "grafana-operator" "grafana-instance" "datasource-prometheus" "datasource-loki" "datasource-tempo" "opencost-pod-identity" "loki-pod-identity" "tempo-pod-identity" "vpa" "goldilocks" "nodepool-observe" "exposure-zitadel-credentials" "exposure-zitadel-providerconfig" "exposure-oidc-app" "exposure-grafana-oidc-app" "exposure-redis-sts" "exposure-oauth2-proxy-deploy" "exposure-waypoint" }}
   {{- $entry := get $observed $key | default dict }}
   {{- $resource := $entry.resource | default dict }}
   {{- $status := $resource.status | default dict }}
@@ -57,6 +57,12 @@
     "redisReady" (get $checkReady "exposure-redis-sts")
     "oidcClientReady" $exposureOidcReady
     "waypointReady" (get $checkReady "exposure-waypoint")
+    "grafanaOidcClientReady" (get $checkReady "exposure-grafana-oidc-app")
+    "grafanaReady" (and
+      (get $checkReady "kube-prometheus-stack")
+      (get $checkReady "exposure-grafana-oidc-app")
+      (get $checkReady "exposure-waypoint")
+    )
   )
 )) }}
 

--- a/functions/render/200-kube-prometheus-stack.yaml.gotmpl
+++ b/functions/render/200-kube-prometheus-stack.yaml.gotmpl
@@ -146,6 +146,68 @@ spec:
     {{- $_ := set $grafanaBase "fullnameOverride" "grafana" }}
     {{- $_ := set $operatorValues "fullnameOverride" "prometheus-operator" }}
     {{- $_ := set $nodeExporterValues "fullnameOverride" "node-exporter" }}
+
+    {{- /* Grafana app-level OIDC (per tasks/observe-stack-grafana-oidc).
+           When spec.exposure.grafana.enabled, layer Helm values for
+           generic_oauth + session knobs onto $grafanaBase. The Zitadel
+           OIDC App composed in 420-* writes client_id + client_secret
+           to <observe-ns>-grafana-oidc-client; we mount that Secret
+           via extraSecretMounts and reference values via $__file{}
+           so the secret never lives in pod env. */}}
+    {{- $g := $state.exposure.grafana }}
+    {{- if $g.enabled }}
+      {{- $grafanaOidcSecret := printf "%s-grafana-oidc-client" $state.namespace }}
+      {{- $grafanaOidcMountPath := "/etc/secrets/grafana-oidc" }}
+      {{- $generic := dict
+        "enabled" true
+        "name" "Zitadel"
+        "allow_sign_up" true
+        "auto_login" $g.autoLogin
+        "client_id" (printf "$__file{%s/attribute.client_id}" $grafanaOidcMountPath)
+        "client_secret" (printf "$__file{%s/attribute.client_secret}" $grafanaOidcMountPath)
+        "scopes" "openid email profile"
+        "auth_url" (printf "%s/oauth/v2/authorize" $state.auth.issuerURL)
+        "token_url" (printf "%s/oauth/v2/token" $state.auth.issuerURL)
+        "api_url" (printf "%s/oidc/v1/userinfo" $state.auth.issuerURL)
+        "use_refresh_token" $g.useRefreshToken
+        "login_attribute_path" "preferred_username"
+        "email_attribute_path" "email"
+        "name_attribute_path" "name"
+      }}
+      {{- if gt (len $g.allowedDomains) 0 }}
+        {{- $_ := set $generic "allowed_domains" (join "," $g.allowedDomains) }}
+      {{- end }}
+      {{- if ne $g.roleAttributePath "" }}
+        {{- $_ := set $generic "role_attribute_path" $g.roleAttributePath }}
+        {{- $_ := set $generic "role_attribute_strict" true }}
+      {{- end }}
+      {{- if ne $g.orgAttributePath "" }}
+        {{- $_ := set $generic "org_attribute_path" $g.orgAttributePath }}
+      {{- end }}
+      {{- if gt (len $g.orgMapping) 0 }}
+        {{- $_ := set $generic "org_mapping" (join "," $g.orgMapping) }}
+      {{- end }}
+      {{- $grafanaIni := dict
+        "server" (dict
+          "domain" $g.host
+          "root_url" (printf "https://%s" $g.host)
+        )
+        "auth.generic_oauth" $generic
+        "auth" (dict
+          "login_maximum_lifetime_duration" $g.maxSessionDuration
+          "token_rotation_interval_minutes" $g.tokenRotationMinutes
+          "oauth_auto_login" $g.autoLogin
+        )
+      }}
+      {{- $_ := set $grafanaBase "grafana.ini" $grafanaIni }}
+      {{- $_ := set $grafanaBase "extraSecretMounts" (list (dict
+        "name" "grafana-oidc"
+        "secretName" $grafanaOidcSecret
+        "mountPath" $grafanaOidcMountPath
+        "readOnly" true
+      )) }}
+    {{- end }}
+
     {{- $grafana := merge $grafanaValues $grafanaBase }}
     {{- /* Build kube-state-metrics values with optional nodeSelector/tolerations */}}
     {{- $ksmBase := dict

--- a/functions/render/400-exposure-zitadel-credentials.yaml.gotmpl
+++ b/functions/render/400-exposure-zitadel-credentials.yaml.gotmpl
@@ -1,0 +1,59 @@
+# code: language=yaml
+#
+# ExternalSecret: pulls Zitadel iam-admin PAT from AWS Secrets Manager into
+# a K8s Secret in the observe namespace. The Zitadel ProviderConfig
+# (410-*) reads this Secret to talk to Zitadel's management API.
+#
+# Mirror of xrs/stacks/k8s/auth/examples/consumer-providerconfig.yaml,
+# rendered by ObserveStack instead of authored per-cluster. AWS SM path +
+# accessTokenProperty come from AuthStack status; operator wires them up
+# via spec.auth.* on ObserveStack (until cross-stack typed refs land).
+
+{{- $x := $state.exposure }}
+{{- $a := $state.auth }}
+{{- if $x.enabled }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-zitadel-credentials
+  annotations:
+    {{ setResourceNameAnnotation "exposure-zitadel-credentials" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: zitadel-credentials
+        namespace: {{ $state.namespace }}
+        labels: {{ $state.labels | toJson }}
+      spec:
+        refreshInterval: 1h
+        secretStoreRef:
+          name: hops-aws-secrets-manager
+          kind: ClusterSecretStore
+        target:
+          name: zitadel-credentials
+          creationPolicy: Owner
+          template:
+            engineVersion: v2
+            data:
+              credentials: |
+                {
+                  "access_token": "{{`{{ .access_token | trim }}`}}",
+                  "domain": {{ $a.zitadelDomain | quote }},
+                  "port": "443",
+                  "insecure": false
+                }
+        data:
+        - secretKey: access_token
+          remoteRef:
+            key: {{ $a.awsSecretsManagerPath | quote }}
+            property: {{ $a.accessTokenProperty | quote }}
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}

--- a/functions/render/410-exposure-zitadel-providerconfig.yaml.gotmpl
+++ b/functions/render/410-exposure-zitadel-providerconfig.yaml.gotmpl
@@ -1,0 +1,37 @@
+# code: language=yaml
+#
+# Zitadel ProviderConfig in the observe namespace, sourcing from the
+# zitadel-credentials Secret rendered in 400-*. Used by the OIDC App MR
+# in 420-* to provision the oauth2-proxy OIDC client in Zitadel.
+
+{{- $x := $state.exposure }}
+{{- if $x.enabled }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-zitadel-providerconfig
+  annotations:
+    {{ setResourceNameAnnotation "exposure-zitadel-providerconfig" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: zitadel.m.crossplane.io/v1beta1
+      kind: ProviderConfig
+      metadata:
+        name: zitadel-observe-stack
+        namespace: {{ $state.namespace }}
+        labels: {{ $state.labels | toJson }}
+      spec:
+        credentials:
+          source: Secret
+          secretRef:
+            name: zitadel-credentials
+            namespace: {{ $state.namespace }}
+            key: credentials
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}

--- a/functions/render/420-exposure-zitadel-oidc-app.yaml.gotmpl
+++ b/functions/render/420-exposure-zitadel-oidc-app.yaml.gotmpl
@@ -1,0 +1,69 @@
+# code: language=yaml
+#
+# Zitadel OIDC Application MR — the OIDC client oauth2-proxy authenticates
+# against. The provider writes client_id + client_secret to a K8s Secret
+# named "<observe-ns>-oauth2-proxy-oidc-client"; the oauth2-proxy
+# Deployment in 460-* mounts those as env vars.
+#
+# Redirect URIs cover every per-component host configured under
+# spec.exposure.*, plus standard logout URLs. Wildcards aren't supported
+# in Zitadel redirect URIs as of v3 — list each host explicitly.
+
+{{- $x := $state.exposure }}
+{{- $a := $state.auth }}
+{{- if $x.enabled }}
+{{- $redirects := list }}
+{{- $postLogout := list }}
+{{- range $comp := $x.components }}
+  {{- if and $comp.enabled (ne $comp.host "") }}
+    {{- $redirects = append $redirects (printf "https://%s/oauth2/callback" $comp.host) }}
+    {{- $postLogout = append $postLogout (printf "https://%s/" $comp.host) }}
+  {{- end }}
+{{- end }}
+{{- $oidcAppName := printf "%s-oauth2-proxy" $state.namespace }}
+{{- $oidcSecretName := printf "%s-oidc-client" $oidcAppName }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-oidc-app
+  annotations:
+    {{ setResourceNameAnnotation "exposure-oidc-app" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: application.zitadel.m.crossplane.io/v1alpha1
+      kind: Oidc
+      metadata:
+        name: {{ $oidcAppName }}
+        namespace: {{ $state.namespace }}
+        labels: {{ $state.labels | toJson }}
+      spec:
+        forProvider:
+          name: {{ $oidcAppName | quote }}
+          projectId: {{ $a.zitadelProjectId | quote }}
+          appType: OIDC_APP_TYPE_WEB
+          authMethodType: OIDC_AUTH_METHOD_TYPE_BASIC
+          grantTypes:
+          - OIDC_GRANT_TYPE_AUTHORIZATION_CODE
+          - OIDC_GRANT_TYPE_REFRESH_TOKEN
+          responseTypes:
+          - OIDC_RESPONSE_TYPE_CODE
+          redirectUris: {{ $redirects | toJson }}
+          postLogoutRedirectUris: {{ $postLogout | toJson }}
+          accessTokenType: OIDC_TOKEN_TYPE_BEARER
+          accessTokenRoleAssertion: true
+          idTokenRoleAssertion: true
+          idTokenUserinfoAssertion: true
+          devMode: false
+        writeConnectionSecretToRef:
+          name: {{ $oidcSecretName }}
+        providerConfigRef:
+          name: zitadel-observe-stack
+          kind: ProviderConfig
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}

--- a/functions/render/420-exposure-zitadel-oidc-app.yaml.gotmpl
+++ b/functions/render/420-exposure-zitadel-oidc-app.yaml.gotmpl
@@ -1,25 +1,37 @@
 # code: language=yaml
 #
-# Zitadel OIDC Application MR — the OIDC client oauth2-proxy authenticates
-# against. The provider writes client_id + client_secret to a K8s Secret
-# named "<observe-ns>-oauth2-proxy-oidc-client"; the oauth2-proxy
-# Deployment in 460-* mounts those as env vars.
+# Zitadel OIDC Application MRs.
 #
-# Redirect URIs cover every per-component host configured under
-# spec.exposure.*, plus standard logout URLs. Wildcards aren't supported
-# in Zitadel redirect URIs as of v3 — list each host explicitly.
+# Two clients composed when their respective auth modes are present:
+#
+# 1. oauth2-proxy client (always, when any ext_authz component enabled) —
+#    one client covering all ext_authz-mode components (prometheus,
+#    alertmanager, opencost). Redirect URIs cover /oauth2/callback on each.
+#    Secret: <observe-ns>-oauth2-proxy-oidc-client.
+#
+# 2. Grafana client (only when spec.exposure.grafana.enabled) — separate
+#    client because Grafana's redirect URI is /login/generic_oauth and the
+#    role/claim mapping is different. App-level OIDC integration per
+#    feedback_app_level_oidc. Secret: <observe-ns>-grafana-oidc-client.
+#
+# Wildcards aren't supported in Zitadel redirect URIs as of v3; list each
+# host explicitly.
 
 {{- $x := $state.exposure }}
 {{- $a := $state.auth }}
 {{- if $x.enabled }}
-{{- $redirects := list }}
-{{- $postLogout := list }}
+
+{{- /* Collect ext_authz-mode component hosts for the oauth2-proxy OIDC client. */}}
+{{- $extAuthzRedirects := list }}
+{{- $extAuthzPostLogout := list }}
 {{- range $comp := $x.components }}
-  {{- if and $comp.enabled (ne $comp.host "") }}
-    {{- $redirects = append $redirects (printf "https://%s/oauth2/callback" $comp.host) }}
-    {{- $postLogout = append $postLogout (printf "https://%s/" $comp.host) }}
+  {{- if and $comp.enabled (ne $comp.host "") (eq $comp.authMode "ext_authz") }}
+    {{- $extAuthzRedirects = append $extAuthzRedirects (printf "https://%s/oauth2/callback" $comp.host) }}
+    {{- $extAuthzPostLogout = append $extAuthzPostLogout (printf "https://%s/" $comp.host) }}
   {{- end }}
 {{- end }}
+
+{{- if gt (len $extAuthzRedirects) 0 }}
 {{- $oidcAppName := printf "%s-oauth2-proxy" $state.namespace }}
 {{- $oidcSecretName := printf "%s-oidc-client" $oidcAppName }}
 ---
@@ -51,8 +63,8 @@ spec:
           - OIDC_GRANT_TYPE_REFRESH_TOKEN
           responseTypes:
           - OIDC_RESPONSE_TYPE_CODE
-          redirectUris: {{ $redirects | toJson }}
-          postLogoutRedirectUris: {{ $postLogout | toJson }}
+          redirectUris: {{ $extAuthzRedirects | toJson }}
+          postLogoutRedirectUris: {{ $extAuthzPostLogout | toJson }}
           accessTokenType: OIDC_TOKEN_TYPE_BEARER
           accessTokenRoleAssertion: true
           idTokenRoleAssertion: true
@@ -66,4 +78,57 @@ spec:
   providerConfigRef:
     name: {{ $state.kubernetes.providerConfigRef.name }}
     kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}
+
+{{- /* Grafana OIDC client (separate, with /login/generic_oauth redirect). */}}
+{{- if and $x.grafana.enabled (ne $x.grafana.host "") }}
+{{- $grafanaOidcName := printf "%s-grafana" $state.namespace }}
+{{- $grafanaOidcSecretName := printf "%s-oidc-client" $grafanaOidcName }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-grafana-oidc-app
+  annotations:
+    {{ setResourceNameAnnotation "exposure-grafana-oidc-app" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: application.zitadel.m.crossplane.io/v1alpha1
+      kind: Oidc
+      metadata:
+        name: {{ $grafanaOidcName }}
+        namespace: {{ $state.namespace }}
+        labels: {{ $state.labels | toJson }}
+      spec:
+        forProvider:
+          name: {{ $grafanaOidcName | quote }}
+          projectId: {{ $a.zitadelProjectId | quote }}
+          appType: OIDC_APP_TYPE_WEB
+          authMethodType: OIDC_AUTH_METHOD_TYPE_BASIC
+          grantTypes:
+          - OIDC_GRANT_TYPE_AUTHORIZATION_CODE
+          - OIDC_GRANT_TYPE_REFRESH_TOKEN
+          responseTypes:
+          - OIDC_RESPONSE_TYPE_CODE
+          redirectUris:
+          - {{ printf "https://%s/login/generic_oauth" $x.grafana.host | quote }}
+          postLogoutRedirectUris:
+          - {{ printf "https://%s/" $x.grafana.host | quote }}
+          accessTokenType: OIDC_TOKEN_TYPE_BEARER
+          accessTokenRoleAssertion: true
+          idTokenRoleAssertion: true
+          idTokenUserinfoAssertion: true
+          devMode: false
+        writeConnectionSecretToRef:
+          name: {{ $grafanaOidcSecretName }}
+        providerConfigRef:
+          name: zitadel-observe-stack
+          kind: ProviderConfig
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}
 {{- end }}

--- a/functions/render/430-exposure-certificate.yaml.gotmpl
+++ b/functions/render/430-exposure-certificate.yaml.gotmpl
@@ -1,0 +1,43 @@
+# code: language=yaml
+#
+# Optional cert-manager Certificate for the exposure wildcard. Skip when
+# the Gateway HTTPS listener already serves an existing wildcard that
+# covers spec.exposure.domain (the common case on pat-local where
+# *.ops.com.ai is already provisioned by cloudflare-dnsstack).
+#
+# When enabled, the cert lands in spec.exposure.certificate.secretNamespace
+# (istio-ingress by default) so the platform Gateway can reference it.
+
+{{- $x := $state.exposure }}
+{{- $cert := $x.certificate }}
+{{- if and $x.enabled $cert.enabled }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-certificate
+  annotations:
+    {{ setResourceNameAnnotation "exposure-certificate" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata:
+        name: {{ $cert.secretName }}
+        namespace: {{ $cert.secretNamespace }}
+        labels: {{ $state.labels | toJson }}
+      spec:
+        secretName: {{ $cert.secretName }}
+        issuerRef:
+          name: {{ $cert.issuerRef.name }}
+          kind: {{ $cert.issuerRef.kind }}
+        dnsNames:
+        - {{ printf "*.%s" $x.domain | quote }}
+        - {{ $x.domain | quote }}
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}

--- a/functions/render/440-exposure-redis.yaml.gotmpl
+++ b/functions/render/440-exposure-redis.yaml.gotmpl
@@ -1,0 +1,123 @@
+# code: language=yaml
+#
+# Single-replica Redis StatefulSet + Service for oauth2-proxy sessions.
+# Sessions are disposable - Pod restart forcing re-login is acceptable
+# (and arguably a security positive). PVC-backed so sessions survive
+# Redis container restarts.
+#
+# TLS is intentionally NOT enabled in v1 - oauth2-proxy <-> Redis stays
+# inside the cluster, ambient mTLS provides transport security between
+# the two pods. Adding redis-side TLS adds operational complexity (cert
+# rotation, CA trust) for negligible defense-in-depth.
+
+{{- $x := $state.exposure }}
+{{- $r := $x.redis }}
+{{- $svcName := printf "%s-oauth2-proxy-redis" $state.namespace }}
+{{- if $x.enabled }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-redis-svc
+  annotations:
+    {{ setResourceNameAnnotation "exposure-redis-svc" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: {{ $svcName }}
+        namespace: {{ $state.namespace }}
+        labels:
+          app.kubernetes.io/name: oauth2-proxy-redis
+          app.kubernetes.io/instance: {{ $state.name }}
+          {{- range $k, $v := $state.labels }}
+          {{ $k }}: {{ $v | quote }}
+          {{- end }}
+      spec:
+        clusterIP: None
+        ports:
+        - name: redis
+          port: 6379
+          targetPort: 6379
+        selector:
+          app.kubernetes.io/name: oauth2-proxy-redis
+          app.kubernetes.io/instance: {{ $state.name }}
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-redis-sts
+  annotations:
+    {{ setResourceNameAnnotation "exposure-redis-sts" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: {{ $svcName }}
+        namespace: {{ $state.namespace }}
+        labels:
+          app.kubernetes.io/name: oauth2-proxy-redis
+          app.kubernetes.io/instance: {{ $state.name }}
+          {{- range $k, $v := $state.labels }}
+          {{ $k }}: {{ $v | quote }}
+          {{- end }}
+      spec:
+        serviceName: {{ $svcName }}
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: oauth2-proxy-redis
+            app.kubernetes.io/instance: {{ $state.name }}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: oauth2-proxy-redis
+              app.kubernetes.io/instance: {{ $state.name }}
+          spec:
+            containers:
+            - name: redis
+              image: {{ $r.image | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["redis-server", "--appendonly", "yes", "--save", "60 1000"]
+              ports:
+              - name: redis
+                containerPort: 6379
+              volumeMounts:
+              - name: data
+                mountPath: /data
+              readinessProbe:
+                tcpSocket:
+                  port: 6379
+                initialDelaySeconds: 5
+                periodSeconds: 5
+              livenessProbe:
+                tcpSocket:
+                  port: 6379
+                initialDelaySeconds: 15
+                periodSeconds: 10
+        volumeClaimTemplates:
+        - metadata:
+            name: data
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: {{ $r.size | quote }}
+            {{- if ne $r.storageClassName "" }}
+            storageClassName: {{ $r.storageClassName | quote }}
+            {{- end }}
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}

--- a/functions/render/445-exposure-waypoint.yaml.gotmpl
+++ b/functions/render/445-exposure-waypoint.yaml.gotmpl
@@ -1,0 +1,89 @@
+# code: language=yaml
+#
+# Waypoint Gateway in the observe namespace + sister Services per enabled
+# component. The Waypoint enforces AuthorizationPolicy.CUSTOM at L7
+# (ambient pattern). HTTPRoutes (470-*) point at the sister Services so
+# traffic traverses the waypoint.
+#
+# Sister Services mirror the upstream pod selector and add
+# istio.io/use-waypoint=<observe-ns>-waypoint so the waypoint intercepts
+# traffic to them. The original Services (kube-prometheus-stack-prometheus,
+# etc.) stay untouched - in-cluster scrape traffic doesn't go through the
+# waypoint, only public exposure traffic does.
+
+{{- $x := $state.exposure }}
+{{- if $x.enabled }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-waypoint
+  annotations:
+    {{ setResourceNameAnnotation "exposure-waypoint" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      metadata:
+        name: {{ $x.waypointName }}
+        namespace: {{ $state.namespace }}
+        labels:
+          istio.io/waypoint-for: service
+          {{- range $k, $v := $state.labels }}
+          {{ $k }}: {{ $v | quote }}
+          {{- end }}
+      spec:
+        gatewayClassName: istio-waypoint
+        listeners:
+        - name: mesh
+          port: 15008
+          protocol: HBONE
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+
+{{- range $comp := $x.components }}
+{{- if and $comp.enabled (ne $comp.host "") }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-sister-svc-{{ $comp.name }}
+  annotations:
+    {{ setResourceNameAnnotation (printf "exposure-sister-svc-%s" $comp.name) }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: {{ $comp.sisterServiceName }}
+        namespace: {{ $state.namespace }}
+        labels:
+          istio.io/use-waypoint: {{ $x.waypointName }}
+          app.kubernetes.io/name: {{ printf "exposure-%s" $comp.name }}
+          app.kubernetes.io/instance: {{ $state.name }}
+          {{- range $k, $v := $state.labels }}
+          {{ $k }}: {{ $v | quote }}
+          {{- end }}
+      spec:
+        type: ClusterIP
+        ports:
+        - name: http
+          port: {{ $comp.servicePort }}
+          targetPort: {{ $comp.servicePort }}
+        selector:
+          {{- range $k, $v := $comp.podSelector }}
+          {{ $k }}: {{ $v | quote }}
+          {{- end }}
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/functions/render/445-exposure-waypoint.yaml.gotmpl
+++ b/functions/render/445-exposure-waypoint.yaml.gotmpl
@@ -65,7 +65,16 @@ spec:
         name: {{ $comp.sisterServiceName }}
         namespace: {{ $state.namespace }}
         labels:
+          # istio.io/use-waypoint routes mesh-internal (ambient) clients via the waypoint.
+          # istio.io/ingress-use-waypoint=true is the additional label that makes Istio
+          # Gateway-API gateways (kind: Gateway, gatewayClassName=istio) also route
+          # through the waypoint when their HTTPRoute backendRef targets this Service.
+          # Without it, the gateway pod HBONE-tunnels direct to the destination pod and
+          # bypasses the waypoint, so AuthorizationPolicy.CUSTOM never fires for north-
+          # south traffic. Available in Istio 1.23+ (1.23.6 / 1.24.3 hardened the WDS
+          # discovery path). See istio/istio#51214.
           istio.io/use-waypoint: {{ $x.waypointName }}
+          istio.io/ingress-use-waypoint: "true"
           app.kubernetes.io/name: {{ printf "exposure-%s" $comp.name }}
           app.kubernetes.io/instance: {{ $state.name }}
           {{- range $k, $v := $state.labels }}

--- a/functions/render/450-exposure-oauth2-proxy.yaml.gotmpl
+++ b/functions/render/450-exposure-oauth2-proxy.yaml.gotmpl
@@ -1,0 +1,174 @@
+# code: language=yaml
+#
+# oauth2-proxy bridge: Deployment + Service.
+#
+# Modes wired up:
+#   - --provider=oidc                 (Zitadel discovery)
+#   - --session-store-type=redis      (server-side sessions)
+#   - --reverse-proxy=true            (X-Forwarded-For trust behind Gateway)
+#   - --skip-provider-button=true     (single IdP, no consent screen)
+#   - --pass-access-token=true        (forward token upstream as a header)
+#   - --set-xauthrequest=true         (set X-Auth-Request-* headers)
+#
+# Listens on :4180. The IstioStack extensionProvider name registered for
+# this bridge points at <observe-ns>-oauth2-proxy.<observe-ns>.svc.cluster.local:4180
+# (per the typed surface added by tasks/istio-stack-extension-providers).
+#
+# Two HTTPRoutes drive traffic to this Service:
+#   - /oauth2/* on every protected host -> oauth2-proxy
+#     (handles /oauth2/auth, /oauth2/start, /oauth2/callback, /oauth2/sign_out)
+#   - AuthorizationPolicy.CUSTOM on each upstream Service triggers waypoint
+#     ext_authz calls to /oauth2/auth on this Service.
+
+{{- $x := $state.exposure }}
+{{- $p := $x.oauth2Proxy }}
+{{- $a := $state.auth }}
+{{- $name := printf "%s-oauth2-proxy" $state.namespace }}
+{{- $redisSvc := printf "%s-oauth2-proxy-redis.%s.svc.cluster.local" $state.namespace $state.namespace }}
+{{- $oidcSecret := printf "%s-oidc-client" $name }}
+{{- if $x.enabled }}
+{{- /* whitelist-domain entries: every component host + the cookie domain */}}
+{{- $whitelist := list $p.cookieDomain }}
+{{- range $comp := $x.components }}
+  {{- if $comp.enabled }}{{- $whitelist = append $whitelist $comp.host }}{{- end }}
+{{- end }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-oauth2-proxy-svc
+  annotations:
+    {{ setResourceNameAnnotation "exposure-oauth2-proxy-svc" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: {{ $name }}
+        namespace: {{ $state.namespace }}
+        labels:
+          app.kubernetes.io/name: oauth2-proxy
+          app.kubernetes.io/instance: {{ $state.name }}
+          {{- range $k, $v := $state.labels }}
+          {{ $k }}: {{ $v | quote }}
+          {{- end }}
+      spec:
+        ports:
+        - name: http
+          port: 4180
+          targetPort: 4180
+        selector:
+          app.kubernetes.io/name: oauth2-proxy
+          app.kubernetes.io/instance: {{ $state.name }}
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-oauth2-proxy-deploy
+  annotations:
+    {{ setResourceNameAnnotation "exposure-oauth2-proxy-deploy" }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: {{ $name }}
+        namespace: {{ $state.namespace }}
+        labels:
+          app.kubernetes.io/name: oauth2-proxy
+          app.kubernetes.io/instance: {{ $state.name }}
+          {{- range $k, $v := $state.labels }}
+          {{ $k }}: {{ $v | quote }}
+          {{- end }}
+      spec:
+        replicas: {{ $p.replicas }}
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: oauth2-proxy
+            app.kubernetes.io/instance: {{ $state.name }}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: oauth2-proxy
+              app.kubernetes.io/instance: {{ $state.name }}
+          spec:
+            containers:
+            - name: oauth2-proxy
+              image: {{ $p.image | quote }}
+              imagePullPolicy: IfNotPresent
+              args:
+              - --http-address=0.0.0.0:4180
+              - --provider=oidc
+              - --provider-display-name=Zitadel
+              - --oidc-issuer-url={{ $a.issuerURL }}
+              - --email-domain=*
+              - --skip-provider-button=true
+              - --reverse-proxy=true
+              - --pass-access-token=true
+              - --pass-authorization-header=true
+              - --set-xauthrequest=true
+              - --set-authorization-header=true
+              - --cookie-domain={{ $p.cookieDomain }}
+              - --cookie-secure=true
+              - --cookie-httponly=true
+              - --cookie-samesite=lax
+              - --cookie-refresh=10m
+              - --session-store-type=redis
+              - --redis-connection-url=redis://{{ $redisSvc }}:6379
+              - --upstream=static://200
+              - --silence-ping-logging=true
+              {{- range $w := $whitelist }}
+              - --whitelist-domain={{ $w }}
+              {{- end }}
+              {{- range $f := $p.additionalConfig }}
+              - {{ $f | quote }}
+              {{- end }}
+              env:
+              # The Zitadel upjet provider writes connection details into
+              # keys prefixed with "attribute." (Terraform convention). The
+              # Oidc MR's writeConnectionSecretToRef Secret therefore carries
+              # attribute.client_id / attribute.client_secret rather than the
+              # plain key names.
+              - name: OAUTH2_PROXY_CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $oidcSecret }}
+                    key: attribute.client_id
+              - name: OAUTH2_PROXY_CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $oidcSecret }}
+                    key: attribute.client_secret
+              - name: OAUTH2_PROXY_COOKIE_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $p.cookieSecretRef.name }}
+                    key: {{ $p.cookieSecretRef.key }}
+              ports:
+              - name: http
+                containerPort: 4180
+              readinessProbe:
+                httpGet:
+                  path: /ready
+                  port: 4180
+                initialDelaySeconds: 5
+                periodSeconds: 5
+              livenessProbe:
+                httpGet:
+                  path: /ping
+                  port: 4180
+                initialDelaySeconds: 10
+                periodSeconds: 10
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}

--- a/functions/render/470-exposure-httproutes.yaml.gotmpl
+++ b/functions/render/470-exposure-httproutes.yaml.gotmpl
@@ -1,0 +1,63 @@
+# code: language=yaml
+#
+# HTTPRoute per enabled component. Each route has two rules:
+#   1. matches: /oauth2/* -> backend: oauth2-proxy (sign-in flow, callback)
+#   2. matches: /         -> backend: upstream service (gated by waypoint)
+#
+# Per spec rule precedence in Gateway API, the more-specific match (the
+# /oauth2/ prefix) is evaluated first, so the OIDC redirect flow always
+# reaches oauth2-proxy even though the upstream is also reachable on /.
+
+{{- $x := $state.exposure }}
+{{- $proxySvc := printf "%s-oauth2-proxy" $state.namespace }}
+{{- if $x.enabled }}
+{{- range $comp := $x.components }}
+{{- if and $comp.enabled (ne $comp.host "") }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-httproute-{{ $comp.name }}
+  annotations:
+    {{ setResourceNameAnnotation (printf "exposure-httproute-%s" $comp.name) }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: gateway.networking.k8s.io/v1
+      kind: HTTPRoute
+      metadata:
+        name: {{ printf "exposure-%s" $comp.name }}
+        namespace: {{ $state.namespace }}
+        labels: {{ $state.labels | toJson }}
+      spec:
+        parentRefs:
+        - name: {{ $x.gatewayRef.name }}
+          namespace: {{ $x.gatewayRef.namespace }}
+          sectionName: {{ $x.gatewayRef.sectionName }}
+        hostnames:
+        - {{ $comp.host | quote }}
+        rules:
+        - matches:
+          - path:
+              type: PathPrefix
+              value: /oauth2
+          backendRefs:
+          - name: {{ $proxySvc }}
+            namespace: {{ $state.namespace }}
+            port: 4180
+        - matches:
+          - path:
+              type: PathPrefix
+              value: /
+          backendRefs:
+          - name: {{ $comp.sisterServiceName }}
+            namespace: {{ $state.namespace }}
+            port: {{ $comp.servicePort }}
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/functions/render/470-exposure-httproutes.yaml.gotmpl
+++ b/functions/render/470-exposure-httproutes.yaml.gotmpl
@@ -1,12 +1,15 @@
 # code: language=yaml
 #
-# HTTPRoute per enabled component. Each route has two rules:
-#   1. matches: /oauth2/* -> backend: oauth2-proxy (sign-in flow, callback)
-#   2. matches: /         -> backend: upstream service (gated by waypoint)
+# HTTPRoute per enabled component. Shape depends on authMode:
+#   - ext_authz (prometheus/alertmanager/opencost): two rules
+#       1. /oauth2/* -> oauth2-proxy (sign-in flow, callback)
+#       2. /         -> sister Service (gated by waypoint ext_authz)
+#   - app_level  (grafana): single rule
+#       1. /         -> sister Service (Grafana enforces its own OIDC auth;
+#                       /login/generic_oauth lives at the app, not oauth2-proxy)
 #
-# Per spec rule precedence in Gateway API, the more-specific match (the
-# /oauth2/ prefix) is evaluated first, so the OIDC redirect flow always
-# reaches oauth2-proxy even though the upstream is also reachable on /.
+# Per Gateway API precedence, the more-specific /oauth2/ prefix is evaluated
+# first when present.
 
 {{- $x := $state.exposure }}
 {{- $proxySvc := printf "%s-oauth2-proxy" $state.namespace }}
@@ -41,6 +44,7 @@ spec:
         hostnames:
         - {{ $comp.host | quote }}
         rules:
+        {{- if eq $comp.authMode "ext_authz" }}
         - matches:
           - path:
               type: PathPrefix
@@ -49,6 +53,7 @@ spec:
           - name: {{ $proxySvc }}
             namespace: {{ $state.namespace }}
             port: 4180
+        {{- end }}
         - matches:
           - path:
               type: PathPrefix

--- a/functions/render/470-exposure-httproutes.yaml.gotmpl
+++ b/functions/render/470-exposure-httproutes.yaml.gotmpl
@@ -33,9 +33,11 @@ spec:
         labels: {{ $state.labels | toJson }}
       spec:
         parentRefs:
+        {{- range $sn := $x.gatewayRef.sectionNames }}
         - name: {{ $x.gatewayRef.name }}
           namespace: {{ $x.gatewayRef.namespace }}
-          sectionName: {{ $x.gatewayRef.sectionName }}
+          sectionName: {{ $sn }}
+        {{- end }}
         hostnames:
         - {{ $comp.host | quote }}
         rules:

--- a/functions/render/480-exposure-auth-policies.yaml.gotmpl
+++ b/functions/render/480-exposure-auth-policies.yaml.gotmpl
@@ -12,7 +12,8 @@
 {{- $x := $state.exposure }}
 {{- if $x.enabled }}
 {{- range $comp := $x.components }}
-{{- if and $comp.enabled (ne $comp.host "") }}
+{{- /* Skip app-level OIDC components (e.g., Grafana): auth happens inside the app, no ext_authz needed. */}}
+{{- if and $comp.enabled (ne $comp.host "") (eq $comp.authMode "ext_authz") }}
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: Object

--- a/functions/render/480-exposure-auth-policies.yaml.gotmpl
+++ b/functions/render/480-exposure-auth-policies.yaml.gotmpl
@@ -1,0 +1,52 @@
+# code: language=yaml
+#
+# AuthorizationPolicy.CUSTOM per enabled component, targetRef on the
+# component's upstream Service. Delegates auth to the IstioStack-registered
+# extensionProvider (default: <observe-ns>-oauth2-proxy). Istio Waypoint
+# enforces; ztunnel correctly reports ZtunnelAccepted=False since CUSTOM
+# is enforced at L7 (waypoint), not at L4 (ztunnel).
+#
+# notPaths excludes /oauth2/* so the OIDC redirect/callback endpoints
+# stay reachable without an existing session.
+
+{{- $x := $state.exposure }}
+{{- if $x.enabled }}
+{{- range $comp := $x.components }}
+{{- if and $comp.enabled (ne $comp.host "") }}
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: {{ $state.name }}-exposure-authpolicy-{{ $comp.name }}
+  annotations:
+    {{ setResourceNameAnnotation (printf "exposure-authpolicy-%s" $comp.name) }}
+  labels: {{ $state.labels | toJson }}
+spec:
+  managementPolicies: {{ $state.managementPolicies | toJson }}
+  forProvider:
+    manifest:
+      apiVersion: security.istio.io/v1
+      kind: AuthorizationPolicy
+      metadata:
+        name: {{ printf "exposure-%s" $comp.name }}
+        namespace: {{ $state.namespace }}
+        labels: {{ $state.labels | toJson }}
+      spec:
+        targetRefs:
+        - group: ""
+          kind: Service
+          name: {{ $comp.sisterServiceName }}
+        action: CUSTOM
+        provider:
+          name: {{ $x.extensionProviderName }}
+        rules:
+        - to:
+          - operation:
+              notPaths:
+              - /oauth2/*
+  providerConfigRef:
+    name: {{ $state.kubernetes.providerConfigRef.name }}
+    kind: {{ $state.kubernetes.providerConfigRef.kind }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/functions/render/999-status.yaml.gotmpl
+++ b/functions/render/999-status.yaml.gotmpl
@@ -4,8 +4,27 @@
 #
 
 {{- $xr := getCompositeResource . }}
+{{- $x := $state.exposure }}
 ---
 apiVersion: {{ $xr.apiVersion }}
 kind: {{ $xr.kind }}
 status:
   ready: {{ $state.status.ready }}
+  {{- if $x.enabled }}
+  exposure:
+    domain: {{ $x.domain | quote }}
+    extensionProviderName: {{ $x.extensionProviderName | quote }}
+    cookieDomain: {{ $x.oauth2Proxy.cookieDomain | quote }}
+    oauth2Proxy:
+      ready: {{ $state.observed.exposure.oauth2ProxyReady }}
+      redisReady: {{ $state.observed.exposure.redisReady }}
+      oidcClientReady: {{ $state.observed.exposure.oidcClientReady }}
+    {{- range $comp := $x.components }}
+    {{ $comp.name }}:
+      enabled: {{ $comp.enabled }}
+      {{- if and $comp.enabled (ne $comp.host "") }}
+      url: {{ printf "https://%s/" $comp.host | quote }}
+      ready: {{ and $state.observed.exposure.oauth2ProxyReady $state.observed.exposure.waypointReady }}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/functions/render/999-status.yaml.gotmpl
+++ b/functions/render/999-status.yaml.gotmpl
@@ -24,7 +24,12 @@ status:
       enabled: {{ $comp.enabled }}
       {{- if and $comp.enabled (ne $comp.host "") }}
       url: {{ printf "https://%s/" $comp.host | quote }}
+      {{- if eq $comp.authMode "app_level" }}
+      ready: {{ $state.observed.exposure.grafanaReady }}
+      oidcClientReady: {{ $state.observed.exposure.grafanaOidcClientReady }}
+      {{- else }}
       ready: {{ and $state.observed.exposure.oauth2ProxyReady $state.observed.exposure.waypointReady }}
+      {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/tests/test-render/main.k
+++ b/tests/test-render/main.k
@@ -2171,6 +2171,7 @@ _items = [
                         metadata.namespace = "monitoring"
                         metadata.labels = {
                             "istio.io/use-waypoint" = "monitoring-waypoint"
+                            "istio.io/ingress-use-waypoint" = "true"
                         }
                         spec.selector = {
                             "app.kubernetes.io/name" = "prometheus"
@@ -2188,6 +2189,18 @@ _items = [
                         metadata.name = "exposure-prometheus"
                         spec = {
                             hostnames = ["prometheus.observe.example.com"]
+                            parentRefs = [
+                                {
+                                    name = "platform"
+                                    namespace = "istio-ingress"
+                                    sectionName = "http"
+                                }
+                                {
+                                    name = "platform"
+                                    namespace = "istio-ingress"
+                                    sectionName = "https-apex"
+                                }
+                            ]
                             rules = [
                                 {
                                     matches = [{ path = { type = "PathPrefix", value = "/oauth2" } }]

--- a/tests/test-render/main.k
+++ b/tests/test-render/main.k
@@ -2260,6 +2260,118 @@ _items = [
     }
 
     # ==========================================================================
+    # exposure: grafana app-level OIDC composes its own Zitadel client,
+    # writes generic_oauth Helm values into kube-prometheus-stack, mounts
+    # the OIDC client Secret, and exposes via single-rule HTTPRoute with
+    # NO AuthorizationPolicy.CUSTOM (Grafana enforces its own auth).
+    # ==========================================================================
+    metav1alpha1.CompositionTest {
+        metadata.name = "exposure-grafana-app-level-oidc-shape"
+        spec = {
+            compositionPath = "apis/observestacks/composition.yaml"
+            xrdPath = "apis/observestacks/definition.yaml"
+            timeoutSeconds = 60
+            validate = False
+            xr = {
+                apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                kind = "ObserveStack"
+                metadata.name = "observe"
+                spec = {
+                    clusterName = "my-cluster"
+                    namespace = "monitoring"
+                    aws.region = "us-east-1"
+                    auth = {
+                        issuerURL = "https://auth.example.com"
+                        awsSecretsManagerPath = "push/my-cluster/zitadel-credentials"
+                        zitadelProjectId = "330000000000000001"
+                    }
+                    exposure = {
+                        enabled = True
+                        domain = "observe.example.com"
+                        oauth2Proxy.cookieSecretRef.name = "observe-oauth2-proxy-cookie"
+                        grafana = {
+                            enabled = True
+                            host = "grafana.observe.example.com"
+                            allowedDomains = ["example.com"]
+                            roleAttributePath = "contains(\"urn:zitadel:iam:org:project:roles\", \"observe-admin\") && \"Admin\" || \"Viewer\""
+                        }
+                    }
+                }
+            }
+            assertResources = [
+                # Dedicated Grafana OIDC client (separate from oauth2-proxy)
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-grafana-oidc-app"
+                    spec.forProvider.manifest = {
+                        apiVersion = "application.zitadel.m.crossplane.io/v1alpha1"
+                        kind = "Oidc"
+                        metadata.name = "monitoring-grafana"
+                        spec = {
+                            forProvider = {
+                                projectId = "330000000000000001"
+                                redirectUris = ["https://grafana.observe.example.com/login/generic_oauth"]
+                                postLogoutRedirectUris = ["https://grafana.observe.example.com/"]
+                            }
+                            writeConnectionSecretToRef.name = "monitoring-grafana-oidc-client"
+                            providerConfigRef.name = "zitadel-observe-stack"
+                        }
+                    }
+                }
+                # Sister Service for grafana (same waypoint labels as ext_authz components)
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-sister-svc-grafana"
+                    spec.forProvider.manifest = {
+                        apiVersion = "v1"
+                        kind = "Service"
+                        metadata.name = "exposure-grafana"
+                        metadata.labels = {
+                            "istio.io/use-waypoint" = "monitoring-waypoint"
+                            "istio.io/ingress-use-waypoint" = "true"
+                        }
+                        spec.selector = {
+                            "app.kubernetes.io/name" = "grafana"
+                            "app.kubernetes.io/instance" = "kube-prometheus-stack"
+                        }
+                    }
+                }
+                # Single-rule HTTPRoute (no /oauth2/* detour — Grafana speaks OIDC itself)
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-httproute-grafana"
+                    spec.forProvider.manifest = {
+                        apiVersion = "gateway.networking.k8s.io/v1"
+                        kind = "HTTPRoute"
+                        metadata.name = "exposure-grafana"
+                        spec.rules = [{
+                            matches = [{ path = { type = "PathPrefix", value = "/" } }]
+                            backendRefs = [{
+                                name = "exposure-grafana"
+                                namespace = "monitoring"
+                                port = 80
+                            }]
+                        }]
+                    }
+                }
+                # XR status surface (app_level branch populates oidcClientReady too)
+                {
+                    apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                    kind = "ObserveStack"
+                    metadata.name = "observe"
+                    status.exposure.grafana = {
+                        enabled = True
+                        url = "https://grafana.observe.example.com/"
+                    }
+                }
+            ]
+        }
+    }
+
+    # ==========================================================================
     # exposure: components default to disabled — no per-component resources
     # ==========================================================================
     metav1alpha1.CompositionTest {

--- a/tests/test-render/main.k
+++ b/tests/test-render/main.k
@@ -2044,6 +2044,249 @@ _items = [
             ]
         }
     }
+
+    # ==========================================================================
+    # exposure: enabled composes the full bridge — Zitadel ExternalSecret,
+    # ProviderConfig, OIDC App, Redis, oauth2-proxy, Waypoint, sister Services,
+    # HTTPRoutes, AuthorizationPolicy.CUSTOM.
+    # ==========================================================================
+    metav1alpha1.CompositionTest {
+        metadata.name = "exposure-enabled-composes-full-bridge"
+        spec = {
+            compositionPath = "apis/observestacks/composition.yaml"
+            xrdPath = "apis/observestacks/definition.yaml"
+            timeoutSeconds = 60
+            validate = False
+            xr = {
+                apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                kind = "ObserveStack"
+                metadata.name = "observe"
+                spec = {
+                    clusterName = "my-cluster"
+                    namespace = "monitoring"
+                    aws.region = "us-east-1"
+                    auth = {
+                        issuerURL = "https://auth.example.com"
+                        awsSecretsManagerPath = "push/my-cluster/zitadel-credentials"
+                        zitadelProjectId = "330000000000000001"
+                    }
+                    exposure = {
+                        enabled = True
+                        domain = "observe.example.com"
+                        extensionProviderName = "monitoring-oauth2-proxy"
+                        oauth2Proxy.cookieSecretRef.name = "observe-oauth2-proxy-cookie"
+                        prometheus = {
+                            enabled = True
+                            host = "prometheus.observe.example.com"
+                        }
+                    }
+                }
+            }
+            assertResources = [
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-zitadel-credentials"
+                    spec.forProvider.manifest = {
+                        apiVersion = "external-secrets.io/v1"
+                        kind = "ExternalSecret"
+                        metadata.name = "zitadel-credentials"
+                        metadata.namespace = "monitoring"
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-zitadel-providerconfig"
+                    spec.forProvider.manifest = {
+                        apiVersion = "zitadel.m.crossplane.io/v1beta1"
+                        kind = "ProviderConfig"
+                        metadata.name = "zitadel-observe-stack"
+                        metadata.namespace = "monitoring"
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-oidc-app"
+                    spec.forProvider.manifest = {
+                        apiVersion = "application.zitadel.m.crossplane.io/v1alpha1"
+                        kind = "Oidc"
+                        metadata.name = "monitoring-oauth2-proxy"
+                        spec = {
+                            forProvider.projectId = "330000000000000001"
+                            forProvider.appType = "OIDC_APP_TYPE_WEB"
+                            forProvider.redirectUris = ["https://prometheus.observe.example.com/oauth2/callback"]
+                            writeConnectionSecretToRef.name = "monitoring-oauth2-proxy-oidc-client"
+                            providerConfigRef.name = "zitadel-observe-stack"
+                        }
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-redis-sts"
+                    spec.forProvider.manifest = {
+                        apiVersion = "apps/v1"
+                        kind = "StatefulSet"
+                        metadata.name = "monitoring-oauth2-proxy-redis"
+                        metadata.namespace = "monitoring"
+                        spec.replicas = 1
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-oauth2-proxy-svc"
+                    spec.forProvider.manifest = {
+                        apiVersion = "v1"
+                        kind = "Service"
+                        metadata.name = "monitoring-oauth2-proxy"
+                        metadata.namespace = "monitoring"
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-waypoint"
+                    spec.forProvider.manifest = {
+                        apiVersion = "gateway.networking.k8s.io/v1"
+                        kind = "Gateway"
+                        metadata.name = "monitoring-waypoint"
+                        metadata.namespace = "monitoring"
+                        metadata.labels = {
+                            "istio.io/waypoint-for" = "service"
+                        }
+                        spec.gatewayClassName = "istio-waypoint"
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-sister-svc-prometheus"
+                    spec.forProvider.manifest = {
+                        apiVersion = "v1"
+                        kind = "Service"
+                        metadata.name = "exposure-prometheus"
+                        metadata.namespace = "monitoring"
+                        metadata.labels = {
+                            "istio.io/use-waypoint" = "monitoring-waypoint"
+                        }
+                        spec.selector = {
+                            "app.kubernetes.io/name" = "prometheus"
+                            prometheus = "kube-prometheus-stack-prometheus"
+                        }
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-httproute-prometheus"
+                    spec.forProvider.manifest = {
+                        apiVersion = "gateway.networking.k8s.io/v1"
+                        kind = "HTTPRoute"
+                        metadata.name = "exposure-prometheus"
+                        spec = {
+                            hostnames = ["prometheus.observe.example.com"]
+                            rules = [
+                                {
+                                    matches = [{ path = { type = "PathPrefix", value = "/oauth2" } }]
+                                    backendRefs = [{
+                                        name = "monitoring-oauth2-proxy"
+                                        namespace = "monitoring"
+                                        port = 4180
+                                    }]
+                                }
+                                {
+                                    matches = [{ path = { type = "PathPrefix", value = "/" } }]
+                                    backendRefs = [{
+                                        name = "exposure-prometheus"
+                                        namespace = "monitoring"
+                                        port = 9090
+                                    }]
+                                }
+                            ]
+                        }
+                    }
+                }
+                {
+                    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+                    kind = "Object"
+                    metadata.name = "observe-exposure-authpolicy-prometheus"
+                    spec.forProvider.manifest = {
+                        apiVersion = "security.istio.io/v1"
+                        kind = "AuthorizationPolicy"
+                        metadata.name = "exposure-prometheus"
+                        spec = {
+                            action = "CUSTOM"
+                            provider.name = "monitoring-oauth2-proxy"
+                            targetRefs = [{
+                                group = ""
+                                kind = "Service"
+                                name = "exposure-prometheus"
+                            }]
+                        }
+                    }
+                }
+                {
+                    apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                    kind = "ObserveStack"
+                    metadata.name = "observe"
+                    status.exposure = {
+                        domain = "observe.example.com"
+                        extensionProviderName = "monitoring-oauth2-proxy"
+                        cookieDomain = ".observe.example.com"
+                        prometheus = {
+                            enabled = True
+                            url = "https://prometheus.observe.example.com/"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+    # ==========================================================================
+    # exposure: components default to disabled — no per-component resources
+    # ==========================================================================
+    metav1alpha1.CompositionTest {
+        metadata.name = "exposure-no-components-still-composes-bridge"
+        spec = {
+            compositionPath = "apis/observestacks/composition.yaml"
+            xrdPath = "apis/observestacks/definition.yaml"
+            timeoutSeconds = 60
+            validate = False
+            xr = {
+                apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                kind = "ObserveStack"
+                metadata.name = "observe"
+                spec = {
+                    clusterName = "my-cluster"
+                    namespace = "monitoring"
+                    aws.region = "us-east-1"
+                    auth = {
+                        issuerURL = "https://auth.example.com"
+                        awsSecretsManagerPath = "push/my-cluster/zitadel-credentials"
+                        zitadelProjectId = "330000000000000001"
+                    }
+                    exposure = {
+                        enabled = True
+                        domain = "observe.example.com"
+                        oauth2Proxy.cookieSecretRef.name = "observe-oauth2-proxy-cookie"
+                    }
+                }
+            }
+            assertResources = [
+                # extensionProviderName defaults to <observe-ns>-oauth2-proxy
+                {
+                    apiVersion = "aws.hops.ops.com.ai/v1alpha1"
+                    kind = "ObserveStack"
+                    metadata.name = "observe"
+                    status.exposure.extensionProviderName = "monitoring-oauth2-proxy"
+                }
+            ]
+        }
+    }
 ]
 
 items = _items


### PR DESCRIPTION
## Summary

Adds `spec.auth` + `spec.exposure` to ObserveStack so internal dashboards (Prometheus, Alertmanager, OpenCost) can be reached from the public internet behind Zitadel OIDC, per `[[specs/platform-public-exposure]]`. The bridge is composed fully:

- **ExternalSecret** pulling the Zitadel iam-admin PAT from AWS Secrets Manager (matches AuthStack's `consumer-providerconfig.yaml` shape inline — no per-cluster authoring).
- **Namespaced Zitadel ProviderConfig** sourcing that Secret.
- **Zitadel OIDC Application MR** via `provider-upjet-zitadel` (declarative, per direction during planning rather than out-of-band). Provider writes `client_id` + `client_secret` into a K8s Secret oauth2-proxy mounts.
- **Single-replica Redis** StatefulSet for oauth2-proxy sessions (PVC, no TLS in v1 — ambient mTLS provides transport security between the two pods).
- **Waypoint Gateway** in the observe namespace + per-component **sister Services** labeled `istio.io/use-waypoint`.
- **HTTPRoute** per component — two-rule (`/oauth2/*` → oauth2-proxy, `/` → sister Service).
- **AuthorizationPolicy.CUSTOM** per component, `provider.name` matches the IstioStack-registered extensionProvider (consumes `[[tasks/istio-stack-extension-providers]]`).
- **Optional cert-manager Certificate** when the platform wildcard at the Gateway doesn't already cover `spec.exposure.domain`.

Grafana app-level OIDC intentionally not included — split into `[[tasks/observe-stack-grafana-oidc]]` for a smaller focused follow-up.

Operator pre-requisites:
1. Cookie-signing Secret in the observe namespace (`kubectl create secret generic <name> --from-literal=cookie_secret=$(openssl rand -hex 16)`).
2. Register matching extensionProvider entry on IstioStack.
3. Zitadel project ID provided via `spec.auth.zitadelProjectId`.

## End-to-end verification on pat-local

Composed OIDC client got `client_id=373507418958665326` in Zitadel ("platform-services" project). Curl through the live stack (from inside the cluster):

```
$ curl -D - http://exposure-prometheus.monitoring:9090/
HTTP/1.1 302 Found
location: https://auth.ops.com.ai/oauth/v2/authorize?client_id=373507418958665326&redirect_uri=...%2Foauth2%2Fcallback&...
set-cookie: _oauth2_proxy_csrf=...; Domain=ops.com.ai; Secure; HttpOnly; SameSite=Lax
```

Waypoint Envoy access log: `302 UAEX ext_authz_denied - inbound-vip|9090|http|exposure-prometheus.monitoring.svc.cluster.local` — UAEX = canonical Envoy `ext_authz_denied` response flag, proving the waypoint really called the registered ext_authz upstream and acted on the response.

## Known limitations (carry into release notes)

- **Platform Gateway → Waypoint routing**: requests entering through the public ELB currently bypass the per-namespace waypoint and HBONE-tunnel direct to the destination pod, so the 302 redirect only fires for in-cluster ambient sources. Same gap surfaced in the istio sibling PR. Needs a follow-up for either ambient-aware gateway or a different routing approach.
- **Sister Service pod selectors** default to stock kube-prometheus-stack v77 conventions; clusters using different chart release names must override `spec.exposure.<comp>.{podSelector, serviceName}` (pat-local does this — release name is `observe`).
- **Cookie secret** still pre-created by operator. Future iteration could compose an ExternalSecret matching the AnalyticsStack pattern.

## Test plan

- [x] `make test` — 30/30 pass (28 existing + 2 new)
- [x] `make validate:all` — 8/8 examples validate (12–29 resources each)
- [x] Live install on pat-local: Zitadel OIDC client provisioned via provider; oauth2-proxy + Redis + Waypoint + sister Service all Ready
- [x] Full curl-through-the-chain proves OIDC flow + ext_authz path (see verification above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public exposure capability for monitoring dashboards (Prometheus, Alertmanager, OpenCost, Grafana) with OAuth2 authentication powered by Zitadel OIDC integration.
  * Introduced configuration options for exposure domain, TLS certificate management, and per-component public access settings.
  * Added support for session management via Redis backend.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hops-ops/aws-observe-stack/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->